### PR TITLE
test: cover chunking and retrieval edge cases

### DIFF
--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -12,6 +12,14 @@ def test_chunk_text_windows_with_overlap():
     assert all(len(c) <= 4 for c in chunks)
 
 
+def test_chunk_text_whitespace_only_returns_no_chunks():
+    assert list(chunk_text("   \n\t")) == []
+
+
+def test_chunk_text_shorter_than_chunk_size_returns_one_chunk():
+    assert list(chunk_text("hello", chunk_size=100, overlap=10)) == ["hello"]
+
+
 def test_chunk_text_empty_and_validation():
     assert list(chunk_text("")) == []
     import pytest

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,11 +1,25 @@
 """Tests for the retrieval algorithms (pure, no AWS)."""
 
+import pytest
+
 from dynavec.models import SearchResult
 from dynavec.retrieval import (
     distance_to_score,
     maximal_marginal_relevance,
     reciprocal_rank_fusion,
 )
+
+
+def test_rrf_rejects_wrong_weights_length():
+    with pytest.raises(ValueError):
+        reciprocal_rank_fusion(
+            [[_r("a")], [_r("b")]],
+            weights=[1.0],
+        )
+
+
+def test_rrf_with_empty_result_lists_returns_empty():
+    assert reciprocal_rank_fusion([[], []]) == []
 
 
 def test_distance_to_score_cosine_monotonic():


### PR DESCRIPTION
## Summary

- Add edge-case tests for whitespace-only and short text chunking
- Verify RRF rejects mismatched weights
- Verify RRF handles empty result lists

## Tests

- `uv run --no-project pytest tests/test_ingest.py tests/test_retrieval.py -q`
- `uv run --no-project ruff check tests/test_ingest.py tests/test_retrieval.py`