### PR TITLE
Add Python 3.13 to CI matrix and pip-audit security job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.9", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
@@ -24,3 +24,18 @@ jobs:
         run: uv run --no-sync ruff check src benchmarks
       - name: Test
         run: uv run --no-sync pytest -q
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+      - name: Install deps
+        run: uv pip install -e ".[dev]"
+      - name: Run pip-audit
+        uses: pypa/gh-action-pip-audit@v1.1.0
+        with:
+          requirements: pyproject.toml


### PR DESCRIPTION
## Summary

- Add Python 3.13 to the test matrix
- Add pip-audit job for dependency vulnerability scanning in CI

## Acceptance Criteria

### Python 3.13 (#114)
- [x] 3.13 matrix entry
- [ ] Green suite (will be verified by CI run)

### Dependency vulnerability audit (#115)
- [x] CI job running pip-audit
- [ ] Triage/allowlist doc (optional - can be addressed separately)

Closes #114
Closes #115
