### PR TITLE
feat: deduplicate ingestion chunks by content

### DIFF
--- a/src/dynavec/ingest.py
+++ b/src/dynavec/ingest.py
@@ -16,6 +16,7 @@ consumes it. Tools and prompts primitives can be adapted the same way.
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from typing import Any
@@ -134,10 +135,18 @@ def ingest(
     Chunk ids are ``"{record_id}#chunk{n}"`` and each carries ``source_id`` /
     ``chunk`` metadata so you can group or delete a whole document later.
     """
+
+    seen_hashes: set[str] = set()
+
     def _documents() -> Iterator[Document]:
         for rec in source:
             rec = rec if isinstance(rec, Record) else Record(**rec)
             for n, piece in enumerate(chunk_text(rec.text, chunk_size, overlap)):
+                content_hash = hashlib.sha256(piece.encode("utf-8")).hexdigest()
+                if content_hash in seen_hashes:
+                    continue
+                seen_hashes.add(content_hash)
+
                 yield Document(
                     id=f"{rec.id}#chunk{n}",
                     text=piece,

--- a/tests/test_client_inmemory.py
+++ b/tests/test_client_inmemory.py
@@ -351,7 +351,7 @@ def test_ingest_chunks_and_stores(db):
         ]
     )
     n = ingest(db, source, chunk_size=10, overlap=0, batch_size=4)
-    assert n == 3 + 1  # doc1 -> 3 chunks, doc2 -> 1 chunk
+    assert n == 3  # doc1 -> 2 unique chunks, doc2 -> 1 chunk
     got = db.get(["doc1#chunk0"])[0]
     assert got.metadata["source_id"] == "doc1"
     assert got.metadata["src"] == "wiki"

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,6 +1,7 @@
 """Tests for chunking + the MCP resource source (pure, no AWS)."""
 
-from dynavec.ingest import MCPResourceSource, Record, chunk_text
+from dynavec.ingest import MCPResourceSource, Record, chunk_text, ingest
+from dynavec.models import UpsertResult
 
 
 def test_chunk_text_windows_with_overlap():
@@ -79,3 +80,29 @@ def test_mcp_uri_filter():
     )
     records = list(MCPResourceSource(session, uri_filter=lambda u: u.startswith("notion")))
     assert [r.id for r in records] == ["notion://a"]
+
+
+class FakeIngestDB:
+    def __init__(self):
+        self.documents = []
+
+    def upsert(self, documents, **kwargs):
+        self.documents.extend(documents)
+        return UpsertResult(count=len(documents), ids=[document.id for document in documents])
+
+
+def test_ingest_deduplicates_identical_chunks_within_run():
+    db = FakeIngestDB()
+    source = [
+        Record(id="doc-a", text="duplicate text"),
+        Record(id="doc-b", text="duplicate text"),
+        Record(id="doc-c", text="unique text"),
+    ]
+
+    count = ingest(db, source, chunk_size=100, overlap=0)
+
+    assert count == 2
+    assert [document.text for document in db.documents] == [
+        "duplicate text",
+        "unique text",
+    ]

--- a/tools/build_docs.py
+++ b/tools/build_docs.py
@@ -581,10 +581,10 @@ def render(slug: str) -> str:
     # sidebar
     side = ['<button class="side__toggle">☰ Menu</button>', '<nav class="side" aria-label="Docs">']
     for group, items in NAV:
-        side.append('<div class="side__group"><p class="side__title">%s</p><ul class="side__list">' % group)
+        side.append(f'<div class="side__group"><p class="side__title">{group}</p><ul class="side__list">')
         for s, label in items:
             cur = ' class="is-current"' if s == slug else ""
-            side.append('<li><a href="%s.html"%s>%s</a></li>' % (s, cur, label))
+            side.append(f'<li><a href="{s}.html"{cur}>{label}</a></li>')
         side.append("</ul></div>")
     side.append("</nav>")
 
@@ -594,15 +594,15 @@ def render(slug: str) -> str:
     prev_a = next_a = ""
     if i > 0:
         p = ORDER[i - 1]
-        prev_a = '<a href="%s.html"><span>Previous</span>%s</a>' % (p, TITLES[p])
+        prev_a = f'<a href="{p}.html"><span>Previous</span>{TITLES[p]}</a>'
     else:
         prev_a = "<span></span>"
     if i < len(ORDER) - 1:
         n = ORDER[i + 1]
-        next_a = '<a href="%s.html" style="text-align:right"><span>Next</span>%s</a>' % (n, TITLES[n])
-    nxt = '<div class="doc__next">%s%s</div>' % (prev_a, next_a)
+        next_a = f'<a href="{n}.html" style="text-align:right"><span>Next</span>{TITLES[n]}</a>'
+    nxt = f'<div class="doc__next">{prev_a}{next_a}</div>'
 
-    crumbs = '<div class="doc__crumbs"><a href="../index.html">dynavec</a> / <a href="index.html">Docs</a> / %s</div>' % title
+    crumbs = f'<div class="doc__crumbs"><a href="../index.html">dynavec</a> / <a href="index.html">Docs</a> / {title}</div>'
 
     return TEMPLATE % {
         "title": title.replace("&amp;", "&"),
@@ -671,7 +671,7 @@ def main() -> None:
     for slug in PAGES:
         with open(os.path.join(OUT, slug + ".html"), "w") as f:
             f.write(render(slug))
-    print("Wrote %d docs pages to %s" % (len(PAGES), os.path.normpath(OUT)))
+    print(f"Wrote {len(PAGES)} docs pages to {os.path.normpath(OUT)}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #63

Adds in-run content-hash deduplication for ingestion chunks. Duplicate chunk
text is skipped while unique chunks continue to be ingested normally.

Updates the existing ingestion test to reflect the deduplicated count.

## Validation

- `uv run pytest` — 66 passed, 2 skipped
- `uv run ruff check .` — passed