### PR TITLE
feat: expose hits and misses counters and stats method on cache backends

### DIFF
--- a/src/dynavec/__init__.py
+++ b/src/dynavec/__init__.py
@@ -20,7 +20,7 @@ Quick start
 
 from __future__ import annotations
 
-from .cache import DynamoDBCache, RedisCache, SemanticCache
+from .cache import BaseCache, DynamoDBCache, RedisCache, SemanticCache
 from .client import Dynavec
 from .config import DynavecConfig
 from .credentials import AWSCredentials
@@ -55,6 +55,7 @@ __all__ = [
     "NamespaceView",
     "ProductQuantizer",
     "GraphStore",
+    "BaseCache",
     "SemanticCache",
     "DynamoDBCache",
     "RedisCache",

--- a/src/dynavec/cache.py
+++ b/src/dynavec/cache.py
@@ -54,6 +54,10 @@ def _deserialize(blob: str) -> list[SearchResult]:
 
 
 class BaseCache(ABC):
+    def __init__(self) -> None:
+        self.hits: int = 0
+        self.misses: int = 0
+
     @abstractmethod
     def get(self, namespace, query_vector, top_k, filter) -> list[SearchResult] | None:
         ...
@@ -61,6 +65,21 @@ class BaseCache(ABC):
     @abstractmethod
     def put(self, namespace, query_vector, top_k, filter, results) -> None:
         ...
+
+    def stats(self) -> dict[str, int | float]:
+        """Return cache hit and miss statistics."""
+        total = self.hits + self.misses
+        hit_rate = (self.hits / total) if total > 0 else 0.0
+        return {
+            "hits": self.hits,
+            "misses": self.misses,
+            "hit_rate": hit_rate,
+        }
+
+    def reset_stats(self) -> None:
+        """Reset hit and miss counters."""
+        self.hits = 0
+        self.misses = 0
 
 
 class SemanticCache(BaseCache):
@@ -72,6 +91,7 @@ class SemanticCache(BaseCache):
     """
 
     def __init__(self, threshold: float = 0.97, max_size: int = 2048) -> None:
+        super().__init__()
         self.threshold = threshold
         self.max_size = max_size
         # key: signature -> OrderedDict[vec_key -> (unit_vec, results)]
@@ -85,6 +105,7 @@ class SemanticCache(BaseCache):
         sig = _signature(namespace, top_k, filter)
         bucket = self._buckets.get(sig)
         if not bucket:
+            self.misses += 1
             return None
         q = self._unit(np.asarray(query_vector, dtype=np.float32))
         best_key, best_sim = None, -1.0
@@ -95,7 +116,9 @@ class SemanticCache(BaseCache):
         if best_key is not None and best_sim >= self.threshold:
             vec, res = bucket.pop(best_key)
             bucket[best_key] = (vec, res)  # move to MRU
+            self.hits += 1
             return res
+        self.misses += 1
         return None
 
     def put(self, namespace, query_vector, top_k, filter, results):
@@ -120,6 +143,7 @@ class DynamoDBCache(BaseCache):
     """
 
     def __init__(self, config, boto_session=None, ttl_seconds: int = 3600) -> None:
+        super().__init__()
         import boto3
 
         session = boto_session or boto3.Session()
@@ -136,9 +160,12 @@ class DynamoDBCache(BaseCache):
         )
         item = resp.get("Item")
         if not item:
+            self.misses += 1
             return None
         if item.get("ttl") and int(item["ttl"]) < int(time.time()):
+            self.misses += 1
             return None  # expired but not yet reaped
+        self.hits += 1
         return _deserialize(item["results"])
 
     def put(self, namespace, query_vector, top_k, filter, results):
@@ -156,6 +183,7 @@ class RedisCache(BaseCache):
     """Shared exact-match cache on Redis / AWS ElastiCache."""
 
     def __init__(self, url: str = "redis://localhost:6379/0", ttl_seconds: int = 3600, client=None):
+        super().__init__()
         if client is not None:
             self._r = client
         else:
@@ -172,7 +200,11 @@ class RedisCache(BaseCache):
 
     def get(self, namespace, query_vector, top_k, filter):
         blob = self._r.get(self._key(namespace, query_vector, top_k, filter))
-        return _deserialize(blob) if blob else None
+        if blob:
+            self.hits += 1
+            return _deserialize(blob)
+        self.misses += 1
+        return None
 
     def put(self, namespace, query_vector, top_k, filter, results):
         self._r.set(

--- a/src/dynavec/client.py
+++ b/src/dynavec/client.py
@@ -27,7 +27,10 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Union
+from typing import TYPE_CHECKING, Any, Union
+
+if TYPE_CHECKING:
+    from .cache import BaseCache
 
 import numpy as np
 
@@ -88,6 +91,11 @@ class Dynavec:
             self.provision()
 
     # ------------------------------------------------------------ lifecycle
+    @property
+    def cache(self) -> BaseCache | None:
+        """The configured query cache, if any."""
+        return self._cache
+
     @property
     def _executor(self) -> ThreadPoolExecutor:
         if self._pool is None:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,6 +1,9 @@
-"""Tests for the SemanticCache (pure, no AWS)."""
+import time
 
-from dynavec.cache import SemanticCache
+import pytest
+
+from dynavec.cache import DynamoDBCache, RedisCache, SemanticCache
+from dynavec.config import DynavecConfig
 from dynavec.models import SearchResult
 
 
@@ -49,3 +52,113 @@ def test_lru_eviction():
     c.put("ns", [0.0, 0.0, 1.0] and [1.0, 1.0], 5, None, _res("c"))  # 3rd -> evict oldest
     total = sum(len(b) for b in c._buckets.values())
     assert total <= 2
+
+
+def test_semantic_cache_stats():
+    c = SemanticCache(threshold=0.9)
+    assert c.stats() == {"hits": 0, "misses": 0, "hit_rate": 0.0}
+
+    # miss on empty
+    assert c.get("ns", [1.0, 0.0], 5, None) is None
+    assert c.stats() == {"hits": 0, "misses": 1, "hit_rate": 0.0}
+
+    # put and hit
+    c.put("ns", [1.0, 0.0], 5, None, _res("a"))
+    hit = c.get("ns", [1.0, 0.0], 5, None)
+    assert hit and hit[0].id == "a"
+    assert c.stats() == {"hits": 1, "misses": 1, "hit_rate": 0.5}
+
+    # near-duplicate hit
+    hit2 = c.get("ns", [0.99, 0.02], 5, None)
+    assert hit2 and hit2[0].id == "a"
+    assert c.hits == 2
+    assert c.misses == 1
+    assert c.stats()["hit_rate"] == pytest.approx(2 / 3)
+
+    # dissimilar miss
+    assert c.get("ns", [0.0, 1.0], 5, None) is None
+    assert c.stats() == {"hits": 2, "misses": 2, "hit_rate": 0.5}
+
+    # reset
+    c.reset_stats()
+    assert c.stats() == {"hits": 0, "misses": 0, "hit_rate": 0.0}
+
+
+def test_dynamodb_cache_stats():
+    class FakeTable:
+        def __init__(self):
+            self.items = {}
+
+        def get_item(self, Key):
+            pk = Key["pk"]
+            if pk in self.items:
+                return {"Item": self.items[pk]}
+            return {}
+
+        def put_item(self, Item):
+            self.items[Item["pk"]] = Item
+
+    class FakeSession:
+        def __init__(self, table):
+            self._table = table
+
+        def resource(self, name, region_name=None):
+            fake_table = self._table
+
+            class Resource:
+                def Table(self, table_name):
+                    return fake_table
+
+            return Resource()
+
+    cfg = DynavecConfig(vector_bucket="b", index="i", table="t", dimension=2)
+    fake_table = FakeTable()
+    session = FakeSession(fake_table)
+
+    cache = DynamoDBCache(cfg, boto_session=session, ttl_seconds=60)
+    assert cache.stats() == {"hits": 0, "misses": 0, "hit_rate": 0.0}
+
+    # miss on empty
+    assert cache.get("ns", [1.0, 0.0], 5, None) is None
+    assert cache.stats() == {"hits": 0, "misses": 1, "hit_rate": 0.0}
+
+    # put and hit
+    cache.put("ns", [1.0, 0.0], 5, None, _res("a"))
+    res = cache.get("ns", [1.0, 0.0], 5, None)
+    assert res and res[0].id == "a"
+    assert cache.stats() == {"hits": 1, "misses": 1, "hit_rate": 0.5}
+
+    # expired ttl -> miss
+    pk = DynamoDBCache._pk("ns", [1.0, 0.0], 5, None)
+    fake_table.items[pk]["ttl"] = int(time.time()) - 100
+    assert cache.get("ns", [1.0, 0.0], 5, None) is None
+    assert cache.stats() == {"hits": 1, "misses": 2, "hit_rate": pytest.approx(1 / 3)}
+
+
+def test_redis_cache_stats():
+    class FakeRedis:
+        def __init__(self):
+            self.data = {}
+
+        def get(self, key):
+            return self.data.get(key)
+
+        def set(self, key, value, ex=None):
+            self.data[key] = value
+
+    fake_redis = FakeRedis()
+    cache = RedisCache(client=fake_redis, ttl_seconds=60)
+    assert cache.stats() == {"hits": 0, "misses": 0, "hit_rate": 0.0}
+
+    # miss
+    assert cache.get("ns", [1.0, 0.0], 5, None) is None
+    assert cache.stats() == {"hits": 0, "misses": 1, "hit_rate": 0.0}
+
+    # put and hit
+    cache.put("ns", [1.0, 0.0], 5, None, _res("b"))
+    res = cache.get("ns", [1.0, 0.0], 5, None)
+    assert res and res[0].id == "b"
+    assert cache.stats() == {"hits": 1, "misses": 1, "hit_rate": 0.5}
+
+    cache.reset_stats()
+    assert cache.stats() == {"hits": 0, "misses": 0, "hit_rate": 0.0}

--- a/tests/test_client_inmemory.py
+++ b/tests/test_client_inmemory.py
@@ -351,10 +351,13 @@ def test_semantic_cache_hits_on_repeat(db):
 
     db._vectors.query = counting_query
 
+    assert db.cache is db._cache
     r1 = db.search("apple pie", top_k=3)
+    assert db.cache.stats() == {"hits": 0, "misses": 1, "hit_rate": 0.0}
     r2 = db.search("apple pie", top_k=3)  # identical -> cache hit
     assert calls["n"] == 1
     assert [x.id for x in r1] == [x.id for x in r2]
+    assert db.cache.stats() == {"hits": 1, "misses": 1, "hit_rate": 0.5}
 
 
 def test_ingest_chunks_and_stores(db):


### PR DESCRIPTION
## Summary

Closes #37

Expose hit and miss counters on SemanticCache, DynamoDBCache, and RedisCache backends.
Add stats method returning hits, misses, and hit rate.
Add reset_stats method to clear counters.
Expose cache property on Dynavec client.

## Validation

- uv run pytest: 71 passed, 2 skipped
- uv run ruff check: passed
