### PR TITLE
Fix collisions in structured storage keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ LlamaIndex, CrewAI, and Strands adapters are on the roadmap; the core client wor
 
 ## Namespaces & multi-tenancy
 
-Every write/read takes a `namespace`. dynavec tags each vector with its namespace and scopes queries to it automatically, so a single index can host many tenants (or many embedding "collections") with clean isolation. DynamoDB keys are `"{namespace}#{id}"` for even partition distribution.
+Every write/read takes a `namespace`. dynavec tags each vector with its namespace and scopes queries to it automatically, so a single index can host many tenants (or many embedding "collections") with clean isolation. DynamoDB keys use escaped `"{namespace}#{id}"` components for even partition distribution, so `#` in namespaces, document IDs, and graph entity IDs remains unambiguous.
 
 ---
 

--- a/src/dynavec/client.py
+++ b/src/dynavec/client.py
@@ -48,10 +48,9 @@ from .provisioning import provision_all
 from .retrieval import distance_to_score, maximal_marginal_relevance
 from .stores import DynamoDBStore, S3VectorsStore
 from .transforms import TransformContext, as_pipeline
-from .utils import chunked
+from .utils import KEY_SEPARATOR, chunked, decode_key_component, encode_key_component
 
 Metadata = dict[str, Any]
-_KEY_SEP = "#"
 _S3_PUT_CHUNK = 500
 _DDB_CHUNK = 500
 
@@ -131,11 +130,11 @@ class Dynavec:
 
     # ------------------------------------------------------------- key helpers
     def _s3_key(self, namespace: str, doc_id: str) -> str:
-        return f"{namespace}{_KEY_SEP}{doc_id}"
+        return f"{encode_key_component(namespace)}{KEY_SEPARATOR}{encode_key_component(doc_id)}"
 
     def _split_key(self, key: str) -> tuple[str, str]:
-        namespace, _, doc_id = key.partition(_KEY_SEP)
-        return namespace, doc_id
+        namespace, _, doc_id = key.partition(KEY_SEPARATOR)
+        return decode_key_component(namespace), decode_key_component(doc_id)
 
     def _run_parallel(self, tasks: list) -> None:
         """Run zero-arg callables; parallel if enabled, else sequential."""

--- a/src/dynavec/graph.py
+++ b/src/dynavec/graph.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from typing import Any
 
 from .config import DynavecConfig
-from .utils import retry
+from .utils import KEY_SEPARATOR, encode_key_component, retry
 
 Props = dict[str, Any]
 
@@ -44,7 +44,10 @@ class GraphStore:
 
     @staticmethod
     def _node_pk(ns: str, entity_id: str) -> str:
-        return f"{ns}#node#{entity_id}"
+        return (
+            f"{encode_key_component(ns)}{KEY_SEPARATOR}node{KEY_SEPARATOR}"
+            f"{encode_key_component(entity_id)}"
+        )
 
     # --------------------------------------------------------------- mutations
     @retry()

--- a/src/dynavec/stores/dynamodb.py
+++ b/src/dynavec/stores/dynamodb.py
@@ -16,7 +16,7 @@ from decimal import Decimal
 from typing import Any
 
 from ..config import DynavecConfig
-from ..utils import retry
+from ..utils import KEY_SEPARATOR, encode_key_component, retry
 
 Metadata = dict[str, Any]
 
@@ -59,7 +59,7 @@ class DynamoDBStore:
 
     @staticmethod
     def _pk(namespace: str, doc_id: str) -> str:
-        return f"{namespace}#{doc_id}"
+        return f"{encode_key_component(namespace)}{KEY_SEPARATOR}{encode_key_component(doc_id)}"
 
     def put_many(
         self,

--- a/src/dynavec/utils.py
+++ b/src/dynavec/utils.py
@@ -14,6 +14,18 @@ from typing import Any, Callable, TypeVar
 
 T = TypeVar("T")
 
+KEY_SEPARATOR = "#"
+
+
+def encode_key_component(value: str) -> str:
+    """Escape the key separator while preserving other legacy key characters."""
+    return value.replace("%", "%25").replace(KEY_SEPARATOR, "%23")
+
+
+def decode_key_component(value: str) -> str:
+    """Restore a component produced by :func:`encode_key_component`."""
+    return value.replace("%23", KEY_SEPARATOR).replace("%25", "%")
+
 # botocore error codes that are safe to retry (throttling / transient).
 _RETRYABLE_CODES = frozenset(
     {

--- a/tests/test_client_inmemory.py
+++ b/tests/test_client_inmemory.py
@@ -374,3 +374,13 @@ def test_ingest_chunks_and_stores(db):
     got = db.get(["doc1#chunk0"])[0]
     assert got.metadata["source_id"] == "doc1"
     assert got.metadata["src"] == "wiki"
+
+
+def test_reserved_key_separator_is_escaped_before_writes(db):
+    db.upsert(
+        [Document(id="doc#one", vector=[1.0] * 8)],
+        namespace="tenant#one",
+    )
+
+    assert list(db._vectors._store) == ["tenant%23one#doc%23one"]
+    assert db._docs._store[("tenant#one", "doc#one")]["text"] is None

--- a/tests/test_key_validation.py
+++ b/tests/test_key_validation.py
@@ -1,0 +1,23 @@
+from dynavec.client import Dynavec
+from dynavec.graph import GraphStore
+from dynavec.stores.dynamodb import DynamoDBStore
+
+
+def test_document_keys_escape_components_without_collisions():
+    first = DynamoDBStore._pk("tenant#one", "doc")
+    second = DynamoDBStore._pk("tenant", "one#doc")
+
+    assert first == "tenant%23one#doc"
+    assert second == "tenant#one%23doc"
+    assert first != second
+
+
+def test_s3_key_round_trips_escaped_components():
+    key = Dynavec._s3_key(None, "tenant#one", "doc%two")
+
+    assert key == "tenant%23one#doc%25two"
+    assert Dynavec._split_key(None, key) == ("tenant#one", "doc%two")
+
+
+def test_graph_keys_escape_namespace_and_entity_id():
+    assert GraphStore._node_pk("tenant#one", "entity#two") == "tenant%23one#node#entity%23two"


### PR DESCRIPTION
## Summary

Structured storage keys used a raw `#` separator between namespaces and identifiers. A `#` inside either component could therefore create the same physical key as a different namespace/identifier pair.

## Changes

- Escape `%` and `#` in namespace, document, and graph entity key components before composing storage keys.
- Decode escaped vector-store keys when reconstructing public namespace and document identifiers.
- Add regression coverage for separator collisions, round-trip decoding, and reserved characters in writes.
- Document the reserved-character behavior for namespaces and identifiers.

## Tests

- `uv run --no-sync pytest -q` — 74 passed, 2 skipped (the skipped tests are opt-in live AWS integration tests).
- `uv run --no-sync ruff check src benchmarks tests/test_client_inmemory.py tests/test_key_validation.py` — passed.
- `uv build` — passed.
- `git diff --check` — passed.

## Compatibility

Normal key components retain their legacy representation; only `%` and `#` are encoded. New writes containing separator characters are unambiguous. Live AWS integration tests were not run because they are opt-in and require an AWS account.

## Issue

Closes #98
