### PR TITLE
feat: add AWS doctor command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,10 +75,14 @@ benchmark = [
     "tabulate>=0.9",
 ]
 
+
 [project.urls]
 Homepage = "https://github.com/your-org/dynavec"
 Documentation = "https://github.com/your-org/dynavec#readme"
 Issues = "https://github.com/your-org/dynavec/issues"
+
+[project.scripts]
+dynavec = "dynavec.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/dynavec"]

--- a/src/dynavec/cli.py
+++ b/src/dynavec/cli.py
@@ -1,0 +1,105 @@
+"""Command-line diagnostics for dynavec."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def _parser() -> argparse.ArgumentParser:
+	parser = argparse.ArgumentParser(prog="dynavec")
+	subparsers = parser.add_subparsers(dest="command")
+	doctor = subparsers.add_parser("doctor", help="check AWS credentials and resource access")
+	doctor.add_argument("--bucket", help="S3 Vectors bucket name")
+	doctor.add_argument("--index", help="S3 Vectors index name")
+	doctor.add_argument("--table", help="DynamoDB table name")
+	doctor.add_argument("--region", help="AWS region")
+	doctor.add_argument("--profile", help="AWS profile name")
+	return parser
+
+
+def _session(profile: str | None, region: str | None):
+	import boto3
+
+	kwargs = {}
+	if profile:
+		kwargs["profile_name"] = profile
+	if region:
+		kwargs["region_name"] = region
+	return boto3.Session(**kwargs)
+
+
+def _check(label: str, callback) -> bool:
+	try:
+		detail = callback()
+	except Exception as exc:  # noqa: BLE001
+		print(f"[FAIL] {label}\n       {exc}")
+		return False
+	print(f"[PASS] {label}")
+	if detail:
+		print(f"       {detail}")
+	return True
+
+
+def _doctor(args: argparse.Namespace) -> int:
+	print("Dynavec doctor\n")
+	session = None
+	checks_passed = True
+
+	def get_session():
+		nonlocal session
+		if session is None:
+			session = _session(args.profile, args.region)
+		return session
+
+	checks_passed &= _check(
+		"AWS credentials / STS identity",
+		lambda: _identity(get_session()),
+	)
+
+	if args.bucket or args.index:
+		if not args.bucket or not args.index:
+			print("[FAIL] S3 Vectors configuration\n       --bucket and --index must be provided together")
+			checks_passed = False
+		else:
+			checks_passed &= _check(
+				f"S3 Vectors index: {args.index}",
+				lambda: _check_s3vectors(get_session(), args.bucket, args.index, args.region),
+			)
+
+	if args.table:
+		checks_passed &= _check(
+			f"DynamoDB table: {args.table}",
+			lambda: _check_dynamodb(get_session(), args.table, args.region),
+		)
+
+	print("\nDoctor checks passed." if checks_passed else "\nDoctor checks failed.")
+	return 0 if checks_passed else 1
+
+
+def _identity(session) -> str:
+	identity = session.client("sts").get_caller_identity()
+	return f"Account: {identity.get('Account', 'unknown')}"
+
+
+def _check_s3vectors(session, bucket: str, index: str, region: str | None) -> str:
+	client = session.client("s3vectors", region_name=region)
+	client.get_index(vectorBucketName=bucket, indexName=index)
+	return f"Bucket: {bucket}"
+
+
+def _check_dynamodb(session, table: str, region: str | None) -> str:
+	session.client("dynamodb", region_name=region).describe_table(TableName=table)
+	return "Accessible"
+
+
+def main(argv: list[str] | None = None) -> int:
+	args = _parser().parse_args(argv)
+	if args.command == "doctor":
+		return _doctor(args)
+	_parser().print_help()
+	return 0
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,81 @@
+from dynavec import cli
+
+
+class _FakeClient:
+    def __init__(self, identity=None, error=None):
+        self.identity = identity or {"Account": "123456789012"}
+        self.error = error
+
+    def get_caller_identity(self):
+        if self.error:
+            raise self.error
+        return self.identity
+
+    def get_index(self, **_kwargs):
+        if self.error:
+            raise self.error
+
+    def describe_table(self, **_kwargs):
+        if self.error:
+            raise self.error
+
+
+class _FakeSession:
+    def __init__(self, error=None):
+        self.error = error
+
+    def client(self, service_name, **_kwargs):
+        return _FakeClient(error=self.error)
+
+
+def test_doctor_passes_with_configured_resources(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_session", lambda _profile, _region: _FakeSession())
+
+    result = cli.main(
+        [
+            "doctor",
+            "--bucket",
+            "vectors",
+            "--index",
+            "docs",
+            "--table",
+            "documents",
+        ]
+    )
+
+    assert result == 0
+    output = capsys.readouterr().out
+    assert "[PASS] AWS credentials / STS identity" in output
+    assert "[PASS] S3 Vectors index: docs" in output
+    assert "[PASS] DynamoDB table: documents" in output
+    assert "Doctor checks passed." in output
+
+
+def test_doctor_fails_when_sts_is_unavailable(monkeypatch, capsys):
+    monkeypatch.setattr(
+        cli,
+        "_session",
+        lambda _profile, _region: _FakeSession(error=RuntimeError("access denied")),
+    )
+
+    result = cli.main(["doctor"])
+
+    assert result == 1
+    output = capsys.readouterr().out
+    assert "[FAIL] AWS credentials / STS identity" in output
+    assert "access denied" in output
+    assert "Doctor checks failed." in output
+
+
+def test_doctor_requires_bucket_and_index_together(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_session", lambda _profile, _region: _FakeSession())
+
+    result = cli.main(["doctor", "--bucket", "vectors"])
+
+    assert result == 1
+    assert "--bucket and --index must be provided together" in capsys.readouterr().out
+
+
+def test_main_without_command_prints_help(capsys):
+    assert cli.main([]) == 0
+    assert "doctor" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- Add a `dynavec doctor` CLI command
- Check AWS credentials and STS identity
- Check S3 Vectors index access
- Check DynamoDB table access
- Provide clear pass/fail output and exit codes
- Add credential-free unit tests for success and failure cases

## Usage

```bash
dynavec doctor
dynavec doctor --bucket my-vectors --index docs --table dynavec_docs
```

The command performs read-only checks and does not create AWS resources.

## Validation
```bash
uv run --no-project pytest -q
uv run --no-project ruff check src tests benchmarks
uv run dynavec --help
uv run dynavec doctor --help
```
Closes #87 