### PR TITLE
feat: add DynamoDB cache TTL jitter

### DIFF
--- a/opensource/dynavec/docs/caching.html
+++ b/opensource/dynavec/docs/caching.html
@@ -77,15 +77,19 @@
 # 1) in-process semantic cache — also serves near-duplicate queries
 db = Dynavec(cfg, embedder=emb, cache=SemanticCache(threshold=0.97))
 
-# 2) durable, shared cache in your own DynamoDB table (TTL expiry)
-db = Dynavec(cfg, embedder=emb, cache=DynamoDBCache(cfg, ttl_seconds=3600))
+# 2) durable, shared cache with TTL jitter to spread simultaneous expiry
+db = Dynavec(
+    cfg,
+    embedder=emb,
+    cache=DynamoDBCache(cfg, ttl_seconds=3600, ttl_jitter_seconds=300),
+)
 
 # 3) sub-millisecond shared cache on Redis / AWS ElastiCache
 db = Dynavec(cfg, embedder=emb, cache=RedisCache("redis://my-elasticache:6379/0"))</code></pre>
 <table class="doc__params">
 <tr><th>Backend</th><th>Best for</th></tr>
 <tr><td><code>SemanticCache</code></td><td>single process; tolerant of near-duplicate hits; zero infra</td></tr>
-<tr><td><code>DynamoDBCache</code></td><td>durable, shared, no extra service; exact-match with TTL</td></tr>
+<tr><td><code>DynamoDBCache</code></td><td>durable, shared, no extra service; exact-match with TTL and optional expiry jitter</td></tr>
 <tr><td><code>RedisCache</code></td><td>many workers/hosts; lowest latency; AWS ElastiCache</td></tr>
 </table>
 <p>Force a fresh search per call with <code>db.search(..., use_cache=False)</code>.</p>

--- a/src/dynavec/cache.py
+++ b/src/dynavec/cache.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import random
 import time
 from abc import ABC, abstractmethod
 from collections import OrderedDict
@@ -140,15 +141,28 @@ class DynamoDBCache(BaseCache):
 
     Enable DynamoDB TTL on the ``ttl`` attribute of your table for automatic
     eviction (items are also treated as expired client-side as a safety net).
+    ``ttl_jitter_seconds`` adds a random delay of up to the configured number
+    of seconds to each expiry, spreading simultaneous writes across an expiry
+    window to reduce cache stampedes.
     """
 
-    def __init__(self, config, boto_session=None, ttl_seconds: int = 3600) -> None:
+    def __init__(
+        self,
+        config,
+        boto_session=None,
+        ttl_seconds: int = 3600,
+        ttl_jitter_seconds: int = 0,
+    ) -> None:
         super().__init__()
         import boto3
+
+        if ttl_jitter_seconds < 0:
+            raise ValueError("ttl_jitter_seconds must be non-negative")
 
         session = boto_session or boto3.Session()
         self._table = session.resource("dynamodb", region_name=config.region).Table(config.table)
         self.ttl_seconds = ttl_seconds
+        self.ttl_jitter_seconds = ttl_jitter_seconds
 
     @staticmethod
     def _pk(namespace, query_vector, top_k, filter) -> str:
@@ -169,12 +183,13 @@ class DynamoDBCache(BaseCache):
         return _deserialize(item["results"])
 
     def put(self, namespace, query_vector, top_k, filter, results):
+        jitter = random.randint(0, self.ttl_jitter_seconds)
         self._table.put_item(
             Item={
                 "pk": self._pk(namespace, query_vector, top_k, filter),
                 "kind": "querycache",
                 "results": _serialize(results),
-                "ttl": int(time.time()) + self.ttl_seconds,
+                "ttl": int(time.time()) + self.ttl_seconds + jitter,
             }
         )
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,4 +1,5 @@
 import time
+from unittest.mock import patch
 
 import pytest
 
@@ -133,6 +134,54 @@ def test_dynamodb_cache_stats():
     fake_table.items[pk]["ttl"] = int(time.time()) - 100
     assert cache.get("ns", [1.0, 0.0], 5, None) is None
     assert cache.stats() == {"hits": 1, "misses": 2, "hit_rate": pytest.approx(1 / 3)}
+
+
+def test_dynamodb_cache_ttl_jitter():
+    class FakeTable:
+        def __init__(self):
+            self.items = []
+
+        def put_item(self, Item):
+            self.items.append(Item)
+
+    class FakeSession:
+        def __init__(self, table):
+            self._table = table
+
+        def resource(self, name, region_name=None):
+            fake_table = self._table
+
+            class Resource:
+                def Table(self, table_name):
+                    return fake_table
+
+            return Resource()
+
+    cfg = DynavecConfig(vector_bucket="b", index="i", table="t", dimension=2)
+    fake_table = FakeTable()
+    session = FakeSession(fake_table)
+    cache = DynamoDBCache(
+        cfg,
+        boto_session=session,
+        ttl_seconds=60,
+        ttl_jitter_seconds=30,
+    )
+
+    with patch("dynavec.cache.time.time", return_value=1_000), patch(
+        "dynavec.cache.random.randint", side_effect=[0, 30]
+    ) as randint:
+        cache.put("ns", [1.0, 0.0], 5, None, _res("a"))
+        cache.put("ns", [0.0, 1.0], 5, None, _res("b"))
+
+    assert [item["ttl"] for item in fake_table.items] == [1_060, 1_090]
+    assert randint.call_args_list == [((0, 30),), ((0, 30),)]
+
+
+def test_dynamodb_cache_rejects_negative_ttl_jitter():
+    cfg = DynavecConfig(vector_bucket="b", index="i", table="t", dimension=2)
+
+    with pytest.raises(ValueError, match="ttl_jitter_seconds must be non-negative"):
+        DynamoDBCache(cfg, ttl_jitter_seconds=-1)
 
 
 def test_redis_cache_stats():

--- a/tools/build_docs.py
+++ b/tools/build_docs.py
@@ -405,8 +405,12 @@ PAGES["caching"] = ("Caching",
 # 1) in-process semantic cache — also serves near-duplicate queries
 db = Dynavec(cfg, embedder=emb, cache=SemanticCache(threshold=0.97))
 
-# 2) durable, shared cache in your own DynamoDB table (TTL expiry)
-db = Dynavec(cfg, embedder=emb, cache=DynamoDBCache(cfg, ttl_seconds=3600))
+# 2) durable, shared cache with TTL jitter to spread simultaneous expiry
+db = Dynavec(
+    cfg,
+    embedder=emb,
+    cache=DynamoDBCache(cfg, ttl_seconds=3600, ttl_jitter_seconds=300),
+)
 
 # 3) sub-millisecond shared cache on Redis / AWS ElastiCache
 db = Dynavec(cfg, embedder=emb, cache=RedisCache("redis://my-elasticache:6379/0"))
@@ -414,7 +418,7 @@ db = Dynavec(cfg, embedder=emb, cache=RedisCache("redis://my-elasticache:6379/0"
 <table class="doc__params">
 <tr><th>Backend</th><th>Best for</th></tr>
 <tr><td><code>SemanticCache</code></td><td>single process; tolerant of near-duplicate hits; zero infra</td></tr>
-<tr><td><code>DynamoDBCache</code></td><td>durable, shared, no extra service; exact-match with TTL</td></tr>
+<tr><td><code>DynamoDBCache</code></td><td>durable, shared, no extra service; exact-match with TTL and optional expiry jitter</td></tr>
 <tr><td><code>RedisCache</code></td><td>many workers/hosts; lowest latency; AWS ElastiCache</td></tr>
 </table>
 <p>Force a fresh search per call with <code>db.search(..., use_cache=False)</code>.</p>


### PR DESCRIPTION
Closes #39.

Adds configurable, non-negative DynamoDB cache TTL jitter so clustered writes expire across a bounded window. Includes deterministic boundary tests and updated generated docs.

Validation: 73 passed, 2 skipped; Ruff passed.

AI-assisted and actively reviewed.
