### PR TITLE
feat: add optional score normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ python -m benchmarks.run_benchmark --backend dynavec \
 
 | Area | What you get | API |
 |------|--------------|-----|
-| **Distance metrics** | Index on cosine/euclidean (S3 Vectors native); client-side rescore in cosine / dot / euclidean / manhattan or a **weighted combination** | `search(..., rescore={"cosine":0.7,"manhattan":0.3})` |
+| **Distance metrics** | Index on cosine/euclidean (S3 Vectors native); client-side rescore in cosine / dot / euclidean / manhattan or a **weighted combination**, with optional result-set normalization | `search(..., rescore="dot", normalize_scores=True)` |
 | **Concurrency** | GIL-aware thread pool — real parallelism for I/O-bound AWS calls; parallel batched writes + `search_many` | `DynavecConfig(max_workers=8)`, `db.search_many([...])` |
 | **Streaming** | Results yielded page-by-page as S3 Vectors paginates, so agents start consuming early | `for hit in db.search_stream(q): ...` |
 | **Namespace RAG** | Per-tenant/collection handles; isolation + even partitioning | `kb = db.namespace("kb"); kb.search(...)` |

--- a/src/dynavec/client.py
+++ b/src/dynavec/client.py
@@ -40,6 +40,7 @@ from .embeddings.base import Embedder
 from .exceptions import ConfigurationError, DimensionMismatchError, NotFoundError
 from .graph import GraphStore
 from .metadata import build_s3_filter, generate_auto_metadata, split_metadata
+from .metrics import normalize_scores as normalize_metric_scores
 from .metrics import rescore as metric_rescore
 from .metrics import score as metric_score
 from .models import Document, SearchResult, UpsertResult
@@ -299,12 +300,15 @@ class Dynavec:
         mmr_lambda: float = 0.5,
         include_vectors: bool = False,
         use_cache: bool | None = None,
+        normalize_scores: bool = False,
     ) -> list[SearchResult]:
         """Semantic search. Provide ``query`` (embedded) or a raw ``vector``.
 
         ``rescore`` re-orders the ANN candidates with a client-side metric
         (``"cosine"``, ``"dot"``, ``"euclidean"``, ``"manhattan"``) or a weighted
         combination like ``{"cosine": 0.7, "manhattan": 0.3}``.
+        Set ``normalize_scores=True`` to min-max normalize the final result set
+        to ``[0, 1]`` without changing its order.
 
         If a cache is configured, repeated/similar queries are served from it
         (set ``use_cache=False`` to force a fresh search).
@@ -317,7 +321,12 @@ class Dynavec:
         if cache_on and self._cache is not None:
             cache_filter = {
                 **(filter or {}),
-                "__rank": {"rescore": rescore, "rerank": rerank, "mmr": mmr_lambda},
+                "__rank": {
+                    "rescore": rescore,
+                    "rerank": rerank,
+                    "mmr": mmr_lambda,
+                    "normalize_scores": normalize_scores,
+                },
             }
             cached = self._cache.get(namespace, query_vector, top_k, cache_filter)
             if cached is not None:
@@ -368,6 +377,11 @@ class Dynavec:
             results = maximal_marginal_relevance(query_vector, results, top_k, mmr_lambda)
         else:
             results = results[:top_k]
+
+        if normalize_scores and results:
+            normalized = normalize_metric_scores(np.asarray([r.score for r in results]))
+            for result, normalized_score in zip(results, normalized):
+                result.score = float(normalized_score)
 
         if not include_vectors:
             for r in results:

--- a/src/dynavec/metrics.py
+++ b/src/dynavec/metrics.py
@@ -44,7 +44,11 @@ def score(query: np.ndarray, mat: np.ndarray, metric: Metric) -> np.ndarray:
     raise ValueError(f"unknown metric {metric!r}; expected one of {_VALID}")
 
 
-def _minmax(x: np.ndarray) -> np.ndarray:
+def normalize_scores(scores: np.ndarray) -> np.ndarray:
+    """Min-max normalize a result set to the inclusive ``[0, 1]`` range."""
+    x = np.asarray(scores, dtype=float)
+    if x.size == 0:
+        return x.copy()
     lo, hi = float(x.min()), float(x.max())
     if hi - lo < 1e-12:
         return np.zeros_like(x)
@@ -68,7 +72,7 @@ def composite_score(
     total = 0.0
     acc = None
     for metric, w in weights.items():
-        s = _minmax(score(query, mat, metric))
+        s = normalize_scores(score(query, mat, metric))
         acc = s * w if acc is None else acc + s * w
         total += w
     return acc / (total or 1.0)
@@ -78,13 +82,18 @@ def rescore(
     query: np.ndarray,
     candidate_vectors: np.ndarray,
     spec: Metric | dict[str, float],
+    *,
+    normalize: bool = False,
 ) -> np.ndarray:
     """Return an ordering (indices, best first) for the candidates under ``spec``.
 
     ``spec`` is a metric name or a ``{metric: weight}`` combination.
+    Set ``normalize`` to min-max normalize the returned score array to ``[0, 1]``.
     """
     if isinstance(spec, str):
         scores = score(query, candidate_vectors, spec)
     else:
         scores = composite_score(query, candidate_vectors, spec)
+    if normalize:
+        scores = normalize_scores(scores)
     return np.argsort(-scores), scores

--- a/tests/test_client_inmemory.py
+++ b/tests/test_client_inmemory.py
@@ -9,7 +9,7 @@ import math
 import pytest
 
 import dynavec.client as client_mod
-from dynavec import Document, Dynavec, DynavecConfig
+from dynavec import Document, Dynavec, DynavecConfig, SemanticCache
 from dynavec.config import NS_METADATA_KEY
 from dynavec.embeddings.base import Embedder
 
@@ -285,6 +285,27 @@ def test_rescore_with_metric(db):
     )
     hits = db.search("apple", top_k=2, rescore={"cosine": 0.5, "manhattan": 0.5})
     assert len(hits) == 2
+
+
+def test_search_can_normalize_final_scores(db):
+    db.upsert(
+        [
+            Document(id="1", text="apple pie recipe"),
+            Document(id="2", text="apple orchard tour"),
+            Document(id="3", text="rocket to mars"),
+        ]
+    )
+
+    db._cache = SemanticCache(threshold=0.999)
+    db.search("apple", top_k=3, rescore="dot")
+
+    hits = db.search("apple", top_k=3, rescore="dot", normalize_scores=True)
+
+    assert db._cache.misses == 2
+    scores = [hit.score for hit in hits]
+    assert scores == sorted(scores, reverse=True)
+    assert max(scores) == pytest.approx(1.0)
+    assert min(scores) == pytest.approx(0.0)
 
 
 def test_transform_applied_on_upsert(db):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from dynavec.metrics import composite_score, rescore, score
+from dynavec.metrics import composite_score, normalize_scores, rescore, score
 
 
 @pytest.fixture
@@ -61,3 +61,17 @@ def test_rescore_returns_order_and_scores(data):
     order, scores = rescore(q, mat, "dot")
     assert list(order)[0] == 2  # largest magnitude first under dot
     assert len(scores) == 3
+
+
+def test_normalize_scores_maps_result_set_to_unit_interval():
+    normalized = normalize_scores(np.array([-2.0, 0.0, 6.0], dtype=np.float32))
+    assert normalized == pytest.approx([0.0, 0.25, 1.0])
+    assert normalize_scores(np.array([4.0, 4.0])) == pytest.approx([0.0, 0.0])
+    assert normalize_scores(np.array([])).size == 0
+
+
+def test_rescore_can_return_normalized_scores(data):
+    q, mat = data
+    order, scores = rescore(q, mat, "dot", normalize=True)
+    assert list(order)[0] == 2
+    assert scores == pytest.approx([0.5, 0.0, 1.0])


### PR DESCRIPTION
Closes #48.

Adds a reusable min-max normalization helper plus an opt-in `normalize_scores` search flag. Normalization applies to the final result set, preserves ranking, and participates in cache identity so raw and normalized results stay separate.

Validation: 74 passed, 2 live-AWS tests skipped; Ruff and diff checks pass.
