### PR TITLE
 Add Voyage AI embedder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
 openai = ["openai>=1.40"]
 gemini = ["google-generativeai>=0.8"]
 cohere = ["cohere>=5.0"]
+voyage = ["voyageai>=0.3.2"]
 sentence-transformers = ["sentence-transformers>=3.0"]
 # bedrock needs nothing beyond boto3.
 
@@ -54,6 +55,7 @@ all = [
     "openai>=1.40",
     "google-generativeai>=0.8",
     "cohere>=5.0",
+    "voyageai>=0.3.2",
     "sentence-transformers>=3.0",
     "redis>=5.0",
     "mcp>=1.0; python_version >= '3.10'",

--- a/src/dynavec/embeddings/__init__.py
+++ b/src/dynavec/embeddings/__init__.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:  # for type checkers / IDEs only
     from .gemini import GeminiEmbedder
     from .openai import OpenAIEmbedder
     from .sentence_transformers import SentenceTransformerEmbedder
+    from .voyage import VoyageEmbedder
 
 __all__ = [
     "Embedder",
@@ -24,6 +25,7 @@ __all__ = [
     "GeminiEmbedder",
     "BedrockEmbedder",
     "SentenceTransformerEmbedder",
+    "VoyageEmbedder",
 ]
 
 _LAZY = {
@@ -34,6 +36,7 @@ _LAZY = {
         "dynavec.embeddings.sentence_transformers",
         "SentenceTransformerEmbedder",
     ),
+    "VoyageEmbedder": ("dynavec.embeddings.voyage", "VoyageEmbedder"),
 }
 
 

--- a/src/dynavec/embeddings/voyage.py
+++ b/src/dynavec/embeddings/voyage.py
@@ -1,0 +1,79 @@
+"""Voyage AI embedder (bring your own VOYAGE_API_KEY)."""
+
+from __future__ import annotations
+
+from ..exceptions import MissingDependencyError
+from .base import Embedder, Vector
+
+# Known output dimensions for common models (used when dimension is not given).
+_MODEL_DIMS = {
+    "voyage-4-large": 1024,
+    "voyage-4": 1024,
+    "voyage-4-lite": 1024,
+    "voyage-code-4": 1024,
+    "voyage-finance-2": 1024,
+    "voyage-law-2": 1024,
+    "voyage-3-large": 1024,
+    "voyage-3.5": 1024,
+    "voyage-3.5-lite": 1024,
+    "voyage-3": 1024,
+    "voyage-3-lite": 512,
+    "voyage-code-3": 1024,
+    "voyage-multilingual-2": 1024,
+    "voyage-large-2": 1536,
+    "voyage-2": 1024,
+}
+
+
+class VoyageEmbedder(Embedder):
+    """Embeds text with Voyage AI's embeddings API.
+
+    Parameters
+    ----------
+    model:
+        Model id, e.g. ``"voyage-4"``.
+    api_key:
+        Optional; falls back to the ``VOYAGE_API_KEY`` environment variable.
+    dimension:
+        Optional override. The voyage-4-*, voyage-3.5-* and voyage-code-3 models
+        support 256/512/1024/2048 via the API's ``output_dimension`` parameter;
+        pass it here to request a different vector size.
+    batch_size:
+        Texts per request. The API caps a single call at 1000 texts; the default
+        stays well under that to also respect the per-request token limit.
+    """
+
+    def __init__(
+        self,
+        model: str = "voyage-4",
+        api_key: str | None = None,
+        dimension: int | None = None,
+        batch_size: int = 128,
+    ) -> None:
+        try:
+            import voyageai
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise MissingDependencyError("VoyageEmbedder", "voyageai", "voyage") from exc
+
+        self.model = model
+        self._client = voyageai.Client(api_key=api_key)
+        self._requested_dim = dimension
+        self.dimension = dimension or _MODEL_DIMS.get(model, 1024)
+        self.batch_size = batch_size
+
+    def _embed(self, texts: list[str], input_type: str) -> list[Vector]:
+        out: list[Vector] = []
+        for i in range(0, len(texts), self.batch_size):
+            chunk = texts[i : i + self.batch_size]
+            kwargs = {"model": self.model, "input_type": input_type}
+            if self._requested_dim is not None:
+                kwargs["output_dimension"] = self._requested_dim
+            resp = self._client.embed(chunk, **kwargs)
+            out.extend(resp.embeddings)
+        return out
+
+    def embed_documents(self, texts: list[str]) -> list[Vector]:
+        return self._embed(texts, "document")
+
+    def embed_query(self, text: str) -> Vector:
+        return self._embed([text], "query")[0]

--- a/tests/test_voyage_embedder.py
+++ b/tests/test_voyage_embedder.py
@@ -1,0 +1,161 @@
+"""Unit tests for VoyageEmbedder.
+
+The ``voyageai`` SDK is an optional extra, so these tests inject a fake module
+into ``sys.modules``: no network, no API key, no dependency on the extra being
+installed.
+"""
+
+import sys
+import types
+
+import pytest
+
+from dynavec.embeddings.voyage import VoyageEmbedder
+from dynavec.exceptions import MissingDependencyError
+
+
+def _vec(text, dim):
+    """Deterministic stand-in vector so tests can assert batching order."""
+    return [float(sum(ord(c) for c in text))] * dim
+
+
+class _FakeResponse:
+    def __init__(self, embeddings):
+        self.embeddings = embeddings
+
+
+class _FakeClient:
+    """Records every embed() call instead of talking to Voyage."""
+
+    def __init__(self, api_key=None):
+        self.api_key = api_key
+        self.calls = []
+
+    def embed(self, texts, model=None, input_type=None, output_dimension=None):
+        self.calls.append(
+            {
+                "texts": list(texts),
+                "model": model,
+                "input_type": input_type,
+                "output_dimension": output_dimension,
+            }
+        )
+        dim = output_dimension or 4
+        return _FakeResponse([_vec(t, dim) for t in texts])
+
+
+@pytest.fixture
+def fake_voyageai(monkeypatch):
+    module = types.ModuleType("voyageai")
+    module.Client = _FakeClient
+    monkeypatch.setitem(sys.modules, "voyageai", module)
+    return module
+
+
+def test_import_does_not_require_the_extra():
+    # Importing the package must not pull in voyageai; the SDK import lives in
+    # __init__ so that this works without `pip install 'dynavec[voyage]'`.
+    assert "voyageai" not in sys.modules
+    from dynavec.embeddings import VoyageEmbedder as Exported
+
+    assert Exported is VoyageEmbedder
+
+
+def test_missing_dependency_raises(monkeypatch):
+    monkeypatch.setitem(sys.modules, "voyageai", None)  # makes `import voyageai` fail
+    with pytest.raises(MissingDependencyError) as exc:
+        VoyageEmbedder()
+    assert "pip install 'dynavec[voyage]'" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("voyage-4", 1024),
+        ("voyage-4-lite", 1024),
+        ("voyage-code-4", 1024),
+        ("voyage-3", 1024),
+        ("voyage-3-lite", 512),
+        ("voyage-code-3", 1024),
+        ("voyage-large-2", 1536),
+    ],
+)
+def test_dimension_from_model_map(fake_voyageai, model, expected):
+    assert VoyageEmbedder(model=model).dimension == expected
+
+
+def test_unknown_model_falls_back_to_1024(fake_voyageai):
+    assert VoyageEmbedder(model="voyage-does-not-exist").dimension == 1024
+
+
+def test_explicit_dimension_overrides_map_and_is_sent(fake_voyageai):
+    emb = VoyageEmbedder(model="voyage-4", dimension=256)
+    assert emb.dimension == 256
+
+    emb.embed_documents(["a"])
+    assert emb._client.calls[0]["output_dimension"] == 256
+
+
+def test_output_dimension_omitted_when_not_requested(fake_voyageai):
+    emb = VoyageEmbedder(model="voyage-4")
+    emb.embed_documents(["a"])
+    assert emb._client.calls[0]["output_dimension"] is None
+
+
+def test_api_key_is_passed_through(fake_voyageai):
+    assert VoyageEmbedder(api_key="sk-test")._client.api_key == "sk-test"
+
+
+def test_api_key_defers_to_env_var_when_omitted(fake_voyageai):
+    # Passing None lets the SDK read VOYAGE_API_KEY itself.
+    assert VoyageEmbedder()._client.api_key is None
+
+
+def test_embed_documents_uses_document_input_type(fake_voyageai):
+    emb = VoyageEmbedder(model="voyage-4")
+    out = emb.embed_documents(["alpha", "beta"])
+
+    assert out == [_vec("alpha", 4), _vec("beta", 4)]
+    assert emb._client.calls == [
+        {
+            "texts": ["alpha", "beta"],
+            "model": "voyage-4",
+            "input_type": "document",
+            "output_dimension": None,
+        }
+    ]
+
+
+def test_embed_query_uses_query_input_type_and_returns_one_vector(fake_voyageai):
+    emb = VoyageEmbedder(model="voyage-4")
+    out = emb.embed_query("alpha")
+
+    assert out == _vec("alpha", 4)
+    assert emb._client.calls[0]["input_type"] == "query"
+    assert emb._client.calls[0]["texts"] == ["alpha"]
+
+
+def test_batching_splits_requests_and_preserves_order(fake_voyageai):
+    texts = ["a", "b", "c", "d", "e"]
+    emb = VoyageEmbedder(model="voyage-4", batch_size=2)
+    out = emb.embed_documents(texts)
+
+    assert [c["texts"] for c in emb._client.calls] == [["a", "b"], ["c", "d"], ["e"]]
+    assert out == [_vec(t, 4) for t in texts]
+
+
+def test_empty_input_makes_no_requests(fake_voyageai):
+    emb = VoyageEmbedder(model="voyage-4")
+    assert emb.embed_documents([]) == []
+    assert emb._client.calls == []
+
+
+def test_api_errors_propagate(fake_voyageai):
+    class _Boom(_FakeClient):
+        def embed(self, texts, **kwargs):
+            raise RuntimeError("rate limited")
+
+    fake_voyageai.Client = _Boom
+    emb = VoyageEmbedder(model="voyage-4")
+    with pytest.raises(RuntimeError, match="rate limited"):
+        emb.embed_documents(["a"])


### PR DESCRIPTION
Closes #3 

Adds VoyageEmbedder alongside the existing OpenAI / Gemini / Bedrock / sentence-transformers backends, following the same lazy-import pattern: `import voyageai` happens inside __init__ and raises MissingDependencyError pointing at the new `voyage` extra, so `from dynavec.embeddings import ...` keeps working without the extra installed.

- Module-level dimension map for current (voyage-4-*) and legacy (voyage-3-*, voyage-2-*) models, verified against Voyage's docs; unknown models fall back to 1024.
- `dimension` override is forwarded as the API's `output_dimension`.
- Voyage's embeddings are asymmetric, so embed_query sends input_type="query" and embed_documents sends "document".
- Tests mock the SDK via sys.modules: no network, no API key, and no need for the extra to be installed.

