### PR TITLE
fix(s3vectors): drain QueryVectors pagination and expose configurable page size (#16)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ htmlcov/
 # Local config / secrets
 .env
 *.local
+.commandcode/

--- a/opensource/dynavec/docs/streaming.html
+++ b/opensource/dynavec/docs/streaming.html
@@ -72,9 +72,10 @@
       <p class="doc__sub">Deliver results to agents page-by-page as they arrive.</p>
       
 <p><code>search_stream()</code> is a generator: it yields hits as S3 Vectors paginates, so an agent can start
-consuming the first results before the full set returns.</p>
-<pre class="code"><code>for hit in db.search_stream("large query", top_k=100, namespace="kb"):
-    handle(hit)   # arrives page by page</code></pre>
+consuming the first results before the full set returns. Amazon S3 Vectors returns at most 100 vectors per response page; dynavec automatically handles <code>nextToken</code> pagination up to the service limit of 10,000 results.</p>
+<pre class="code"><code>for hit in db.search_stream("large query", top_k=250, namespace="kb", page_size=50):
+    handle(hit)   # arrives chunked by page_size (or default AWS page size)</code></pre>
+<p>You can also configure default client-side page sizing via <code>DynavecConfig(top_k_page_size=50)</code>.</p>
 <div class="callout">Reranking and rescoring need the full candidate set, so they are not applied in
 streaming mode. Use <a href="search.html">search()</a> when you need them.</div>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ packages = ["src/dynavec"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["src"]
 addopts = "-q"
 
 [tool.ruff]

--- a/src/dynavec/client.py
+++ b/src/dynavec/client.py
@@ -156,8 +156,11 @@ class Dynavec:
             for d in docs:
                 ctx = pipeline(
                     TransformContext(
-                        id=d.id, text=d.text, vector=d.vector,
-                        metadata=dict(d.metadata), namespace=namespace,
+                        id=d.id,
+                        text=d.text,
+                        vector=d.vector,
+                        metadata=dict(d.metadata),
+                        namespace=namespace,
                     )
                 )
                 d.text, d.vector, d.metadata = ctx.text, ctx.vector, ctx.metadata
@@ -341,12 +344,17 @@ class Dynavec:
         results: list[SearchResult] = []
         for doc_id, distance in hits:
             doc = hydrated.get(doc_id, {})
-            vec = vec_by_key.get(self._s3_key(namespace, doc_id), {}).get("vector") if vec_by_key else None
+            vec = (
+                vec_by_key.get(self._s3_key(namespace, doc_id), {}).get("vector")
+                if vec_by_key
+                else None
+            )
             results.append(
                 SearchResult(
                     id=doc_id,
                     score=distance_to_score(distance, self.config.distance_metric)
-                    if distance is not None else 0.0,
+                    if distance is not None
+                    else 0.0,
                     distance=distance,
                     text=doc.get("text"),
                     metadata=doc.get("metadata", {}),
@@ -392,21 +400,30 @@ class Dynavec:
         top_k: int = 50,
         namespace: str = "default",
         filter: Metadata | None = None,
+        page_size: int | None = None,
     ) -> Iterator[SearchResult]:
         """Stream results to the agent page-by-page as S3 Vectors returns them.
 
         A generator: the caller (agent) can start consuming the first hits before
         the full result set is retrieved. Reranking/rescoring are not applied in
         streaming mode (they need the whole candidate set).
+
+        Parameters
+        ----------
+        page_size:
+            Optional chunk size for yielded pages. Defaults to
+            ``DynavecConfig.top_k_page_size`` or service page size.
         """
         query_vector = self._resolve_query_vector(query, vector)
         yielded = 0
+        effective_page_size = page_size if page_size is not None else self.config.top_k_page_size
         for page in self._vectors.query_pages(
             query_vector=query_vector,
             top_k=top_k,
             filter=build_s3_filter(filter, namespace),
             return_metadata=True,
             return_distance=True,
+            page_size=effective_page_size,
         ):
             page_hits = [(self._split_key(v["key"])[1], v.get("distance")) for v in page]
             hydrated = self._docs.get_many(namespace, [h[0] for h in page_hits])
@@ -417,7 +434,8 @@ class Dynavec:
                 yield SearchResult(
                     id=doc_id,
                     score=distance_to_score(distance, self.config.distance_metric)
-                    if distance is not None else 0.0,
+                    if distance is not None
+                    else 0.0,
                     distance=distance,
                     text=doc.get("text"),
                     metadata=doc.get("metadata", {}),
@@ -434,9 +452,7 @@ class Dynavec:
         ]
         return [f.result() for f in futures]
 
-    def _resolve_query_vector(
-        self, query: str | None, vector: list[float] | None
-    ) -> list[float]:
+    def _resolve_query_vector(self, query: str | None, vector: list[float] | None) -> list[float]:
         if vector is not None:
             if len(vector) != self.config.dimension:
                 raise DimensionMismatchError(
@@ -530,12 +546,12 @@ class Dynavec:
         if not doc_ids:
             return []
 
-        vec_by_key = self._vectors.get_vectors(
-            [self._s3_key(namespace, d) for d in doc_ids]
-        )
+        vec_by_key = self._vectors.get_vectors([self._s3_key(namespace, d) for d in doc_ids])
         hydrated = self._docs.get_many(namespace, doc_ids)
 
-        scored = [d for d in doc_ids if vec_by_key.get(self._s3_key(namespace, d), {}).get("vector")]
+        scored = [
+            d for d in doc_ids if vec_by_key.get(self._s3_key(namespace, d), {}).get("vector")
+        ]
         if not scored:
             return []
         mat = np.asarray(
@@ -551,8 +567,10 @@ class Dynavec:
             doc = hydrated.get(d, {})
             out.append(
                 SearchResult(
-                    id=d, score=float(scores[int(i)]),
-                    text=doc.get("text"), metadata=doc.get("metadata", {}),
+                    id=d,
+                    score=float(scores[int(i)]),
+                    text=doc.get("text"),
+                    metadata=doc.get("metadata", {}),
                 )
             )
         return out
@@ -560,7 +578,9 @@ class Dynavec:
     def delete(self, ids: list[str], namespace: str = "default") -> None:
         """Delete documents from both stores."""
         keys = [self._s3_key(namespace, doc_id) for doc_id in ids]
-        self._run_parallel([
-            lambda: self._vectors.delete_vectors(keys),
-            lambda: self._docs.delete_many(namespace, ids),
-        ])
+        self._run_parallel(
+            [
+                lambda: self._vectors.delete_vectors(keys),
+                lambda: self._docs.delete_many(namespace, ids),
+            ]
+        )

--- a/src/dynavec/config.py
+++ b/src/dynavec/config.py
@@ -65,6 +65,7 @@ class DynavecConfig:
 
     # retrieval tuning
     over_fetch: int = 4
+    top_k_page_size: int | None = None
 
     # concurrency (I/O-bound: threads give real parallelism as boto3 releases
     # the GIL during network calls). See client._executor.
@@ -82,3 +83,5 @@ class DynavecConfig:
             raise ValueError("distance_metric must be 'cosine' or 'euclidean'")
         if self.over_fetch < 1:
             raise ValueError("over_fetch must be >= 1")
+        if self.top_k_page_size is not None and self.top_k_page_size <= 0:
+            raise ValueError("top_k_page_size must be a positive integer")

--- a/src/dynavec/stores/s3vectors.py
+++ b/src/dynavec/stores/s3vectors.py
@@ -21,6 +21,7 @@ Metadata = dict[str, Any]
 # PutVectors accepts up to 500 vectors per call.
 _PUT_LIMIT = 500
 _GET_LIMIT = 100
+_MAX_TOP_K = 10000
 
 
 def _f32(vector: list[float]) -> list[float]:
@@ -81,12 +82,25 @@ class S3VectorsStore:
         return_metadata: bool = True,
         return_distance: bool = True,
     ) -> list[dict[str, Any]]:
-        """Run an ANN query. Returns a list of ``{key, distance?, metadata?}``."""
-        kwargs = self._query_kwargs(
-            query_vector, top_k, filter, return_metadata, return_distance
-        )
-        resp = self._client.query_vectors(**kwargs)
-        return resp.get("vectors", [])
+        """Run an ANN query. Drains paginated results up to ``top_k``."""
+        if top_k <= 0:
+            return []
+        if top_k > _MAX_TOP_K:
+            raise ValueError(
+                f"top_k ({top_k}) exceeds Amazon S3 Vectors maximum limit of {_MAX_TOP_K}."
+            )
+        results: list[dict[str, Any]] = []
+        for page in self.query_pages(
+            query_vector,
+            top_k,
+            filter=filter,
+            return_metadata=return_metadata,
+            return_distance=return_distance,
+        ):
+            results.extend(page)
+            if len(results) >= top_k:
+                break
+        return results[:top_k]
 
     def query_pages(
         self,
@@ -95,20 +109,69 @@ class S3VectorsStore:
         filter: Metadata | None = None,
         return_metadata: bool = True,
         return_distance: bool = True,
+        page_size: int | None = None,
     ) -> Iterator[list[dict[str, Any]]]:
         """Yield result **pages** as the S3 Vectors paginator returns them.
 
         This is what powers streaming search: an agent can begin consuming the
         first page while later pages are still in flight.
+
+        Parameters
+        ----------
+        page_size:
+            Optional client-side chunk size for yielded pages. When None (default),
+            yields the raw pages returned by Amazon S3 Vectors (up to 100 per page).
         """
-        kwargs = self._query_kwargs(
-            query_vector, top_k, filter, return_metadata, return_distance
+        if top_k <= 0:
+            return
+        if top_k > _MAX_TOP_K:
+            raise ValueError(
+                f"top_k ({top_k}) exceeds Amazon S3 Vectors maximum limit of {_MAX_TOP_K}."
+            )
+
+        effective_page_size = (
+            page_size if page_size is not None else getattr(self._config, "top_k_page_size", None)
         )
+        if effective_page_size is not None and effective_page_size <= 0:
+            raise ValueError("page_size must be a positive integer.")
+
+        kwargs = self._query_kwargs(query_vector, top_k, filter, return_metadata, return_distance)
         paginator = self._client.get_paginator("query_vectors")
-        for page in paginator.paginate(**kwargs):
+        yielded = 0
+        buffer: list[dict[str, Any]] = []
+
+        for page in paginator.paginate(
+            PaginationConfig={"MaxItems": top_k},
+            **kwargs,
+        ):
             vectors = page.get("vectors", [])
-            if vectors:
+            if not vectors:
+                continue
+
+            if effective_page_size is None:
+                remaining = top_k - yielded
+                if len(vectors) > remaining:
+                    vectors = vectors[:remaining]
                 yield vectors
+                yielded += len(vectors)
+                if yielded >= top_k:
+                    return
+            else:
+                buffer.extend(vectors)
+                while len(buffer) >= effective_page_size and yielded < top_k:
+                    chunk = buffer[:effective_page_size]
+                    buffer = buffer[effective_page_size:]
+                    remaining = top_k - yielded
+                    if len(chunk) > remaining:
+                        chunk = chunk[:remaining]
+                    yield chunk
+                    yielded += len(chunk)
+                    if yielded >= top_k:
+                        return
+
+        if effective_page_size is not None and buffer and yielded < top_k:
+            remaining = top_k - yielded
+            yield buffer[:remaining]
 
     @retry()
     def get_vectors(

--- a/tests/test_client_inmemory.py
+++ b/tests/test_client_inmemory.py
@@ -65,11 +65,14 @@ class FakeS3(client_mod.S3VectorsStore):
         scored.sort(key=lambda x: x[1])
         return [{"key": k, "distance": d, "metadata": m} for k, d, m in scored[:top_k]]
 
-    def query_pages(self, query_vector, top_k, filter=None, return_metadata=True, return_distance=True):
+    def query_pages(
+        self, query_vector, top_k, filter=None, return_metadata=True, return_distance=True, page_size=None
+    ):
         # emulate a paginator: split the result into pages of 2
         hits = self.query(query_vector, top_k, filter, return_metadata, return_distance)
-        for i in range(0, len(hits), 2):
-            yield hits[i : i + 2]
+        chunk_size = page_size or 2
+        for i in range(0, len(hits), chunk_size):
+            yield hits[i : i + chunk_size]
 
     def get_vectors(self, keys, return_metadata=False):
         return {k: {"vector": self._store[k][0], "metadata": self._store[k][1]} for k in keys if k in self._store}

--- a/tests/test_s3vectors.py
+++ b/tests/test_s3vectors.py
@@ -1,0 +1,132 @@
+"""Unit tests for S3VectorsStore pagination, service limits, and page sizing."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from dynavec.config import DynavecConfig
+from dynavec.stores.s3vectors import _MAX_TOP_K, S3VectorsStore
+
+
+@pytest.fixture
+def store():
+    cfg = DynavecConfig(
+        vector_bucket="test-bucket",
+        index="test-index",
+        table="test-table",
+        dimension=4,
+    )
+    mock_session = MagicMock()
+    return S3VectorsStore(cfg, boto_session=mock_session)
+
+
+def test_query_single_page(store):
+    """When results fit in a single page (<100), returns them directly."""
+    mock_paginator = MagicMock()
+    mock_paginator.paginate.return_value = [
+        {"vectors": [{"key": f"k{i}", "distance": 0.01 * i} for i in range(50)]}
+    ]
+    store._client.get_paginator.return_value = mock_paginator
+
+    results = store.query(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=50)
+
+    assert len(results) == 50
+    assert results[0]["key"] == "k0"
+    assert results[-1]["key"] == "k49"
+    store._client.get_paginator.assert_called_once_with("query_vectors")
+
+
+def test_query_multi_page_pagination(store):
+    """When top_k > 100, drains multiple pages across nextTokens."""
+    mock_paginator = MagicMock()
+    page1 = [{"key": f"k{i}"} for i in range(100)]
+    page2 = [{"key": f"k{i}"} for i in range(100, 200)]
+    page3 = [{"key": f"k{i}"} for i in range(200, 250)]
+    mock_paginator.paginate.return_value = [
+        {"vectors": page1},
+        {"vectors": page2},
+        {"vectors": page3},
+    ]
+    store._client.get_paginator.return_value = mock_paginator
+
+    results = store.query(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=250)
+
+    assert len(results) == 250
+    assert results[0]["key"] == "k0"
+    assert results[99]["key"] == "k99"
+    assert results[100]["key"] == "k100"
+    assert results[249]["key"] == "k249"
+
+
+def test_query_truncation_at_top_k(store):
+    """Ensures results are strictly truncated to top_k if a page yields excess items."""
+    mock_paginator = MagicMock()
+    page1 = [{"key": f"k{i}"} for i in range(100)]
+    page2 = [{"key": f"k{i}"} for i in range(100, 200)]
+    mock_paginator.paginate.return_value = [{"vectors": page1}, {"vectors": page2}]
+    store._client.get_paginator.return_value = mock_paginator
+
+    results = store.query(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=130)
+
+    assert len(results) == 130
+    assert results[-1]["key"] == "k129"
+
+
+def test_query_fewer_results_than_top_k(store):
+    """When index has fewer vectors than requested top_k, returns all available without hanging."""
+    mock_paginator = MagicMock()
+    mock_paginator.paginate.return_value = [{"vectors": [{"key": "k0"}, {"key": "k1"}]}]
+    store._client.get_paginator.return_value = mock_paginator
+
+    results = store.query(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=50)
+
+    assert len(results) == 2
+
+
+def test_query_zero_or_negative_top_k(store):
+    """Returns empty list immediately without issuing API calls."""
+    assert store.query(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=0) == []
+    assert store.query(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=-5) == []
+    store._client.get_paginator.assert_not_called()
+
+
+def test_query_exceeding_service_limit(store):
+    """Raises ValueError if top_k exceeds S3 Vectors ceiling (10,000)."""
+    with pytest.raises(ValueError, match="exceeds Amazon S3 Vectors maximum limit"):
+        store.query(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=_MAX_TOP_K + 1)
+
+
+def test_query_pages_raw_chunks(store):
+    """query_pages yields raw pages when page_size is None."""
+    mock_paginator = MagicMock()
+    page1 = [{"key": f"k{i}"} for i in range(100)]
+    page2 = [{"key": f"k{i}"} for i in range(100, 150)]
+    mock_paginator.paginate.return_value = [{"vectors": page1}, {"vectors": page2}]
+    store._client.get_paginator.return_value = mock_paginator
+
+    pages = list(store.query_pages(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=150))
+
+    assert len(pages) == 2
+    assert len(pages[0]) == 100
+    assert len(pages[1]) == 50
+
+
+def test_query_pages_configurable_page_size(store):
+    """query_pages yields chunks corresponding to the requested page_size."""
+    mock_paginator = MagicMock()
+    page1 = [{"key": f"k{i}"} for i in range(25)]
+    mock_paginator.paginate.return_value = [{"vectors": page1}]
+    store._client.get_paginator.return_value = mock_paginator
+
+    pages = list(store.query_pages(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=25, page_size=10))
+
+    assert len(pages) == 3
+    assert len(pages[0]) == 10
+    assert len(pages[1]) == 10
+    assert len(pages[2]) == 5
+
+
+def test_query_pages_invalid_page_size(store):
+    """Raises ValueError when page_size is <= 0."""
+    with pytest.raises(ValueError, match="page_size must be a positive integer"):
+        list(store.query_pages(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=10, page_size=0))


### PR DESCRIPTION
Fixes #16.

### Summary of Changes

- **QueryVectors Pagination Drain**: \S3VectorsStore.query()\ previously issued a single call to \query_vectors\, returning only the first page. Because Amazon S3 Vectors caps each response page at 100 vectors, queries requesting \	op_k > 100\ (or \	op_k > 25\ when default \over_fetch=4\ reranking was active) silently truncated candidates. \query()\ now drains all paginated results via \query_pages()\ up to \	op_k\.
- **Configurable Page Size Controls**:
  - Added \page_size: int | None = None\ parameter to \S3VectorsStore.query_pages()\ and \Dynavec.search_stream()\.
  - Added \	op_k_page_size: int | None = None\ to \DynavecConfig\.
  - When specified, yielded pages are chunked into the requested page size; when \None\, raw S3 Vectors pages (up to 100) are yielded.
- **Service Boundaries**:
  - Enforced Amazon S3 Vectors ceiling \_MAX_TOP_K = 10,000\ (\ValueError\ if exceeded).
  - Short-circuited \	op_k <= 0\ to return \[]\ without unnecessary API calls.
  - Validated that \page_size\ / \	op_k_page_size\ must be positive integers.
- **Documentation**: Updated \streaming.html\ docs detailing pagination, service limits, and page-size options.
- **Regression Test Coverage**: Added \	ests/test_s3vectors.py\ covering single-page, multi-page (100+100+50 items for \	op_k=250\), truncation boundaries, index exhaustion, invalid parameters, and chunked streaming.