### PR TITLE
fix(s3vectors): drain QueryVectors pages and add page_size (#16)

### DIFF
--- a/opensource/dynavec/docs/configuration.html
+++ b/opensource/dynavec/docs/configuration.html
@@ -84,6 +84,7 @@ cfg = DynavecConfig(
     region="us-east-1",
     filterable_keys=["topic"],    # metadata keys pushed to S3 Vectors for filtering
     over_fetch=4,                 # candidate multiplier when reranking
+    top_k_page_size=50,           # optional client-side stream batch size
     max_workers=8,                # thread pool for parallel I/O
     auto_provision=True,
 )</code></pre>
@@ -94,6 +95,7 @@ cfg = DynavecConfig(
 <tr><td><code>distance_metric</code></td><td>The S3 Vectors index metric. Other metrics are available at rerank time — see <a href="metrics-and-rerank.html">Metrics</a>.</td></tr>
 <tr><td><code>filterable_keys</code></td><td>Small allowlist of metadata pushed to S3 Vectors. Everything else lives only in DynamoDB. Keep it small.</td></tr>
 <tr><td><code>over_fetch</code></td><td>How many extra candidates to pull before reranking/rescoring.</td></tr>
+<tr><td><code>top_k_page_size</code></td><td>Client-side stream hydration batch. <code>None</code> (default) uses native S3 Vectors pages (at most 100). Does not change the service page size.</td></tr>
 <tr><td><code>max_workers</code>, <code>parallel_writes</code></td><td>Thread-pool <a href="concurrency.html">concurrency</a> controls.</td></tr>
 </table>
 

--- a/opensource/dynavec/docs/streaming.html
+++ b/opensource/dynavec/docs/streaming.html
@@ -71,10 +71,12 @@
       <h1>Streaming</h1>
       <p class="doc__sub">Deliver results to agents page-by-page as they arrive.</p>
       
-<p><code>search_stream()</code> is a generator: it yields hits as S3 Vectors paginates, so an agent can start
-consuming the first results before the full set returns.</p>
-<pre class="code"><code>for hit in db.search_stream("large query", top_k=100, namespace="kb"):
-    handle(hit)   # arrives page by page</code></pre>
+<p><code>search_stream()</code> is a generator: it yields one hit at a time as S3 Vectors paginates, so an agent can start
+consuming the first results before the full set returns. Amazon S3 Vectors returns at most 100 vectors per response page;
+dynavec follows <code>nextToken</code> up to the service limit of 10,000 results.</p>
+<pre class="code"><code>for hit in db.search_stream("large query", top_k=250, namespace="kb", page_size=50):
+    handle(hit)   # one hit at a time; page_size is the DynamoDB hydration batch</code></pre>
+<p><code>page_size</code> (or <code>DynavecConfig(top_k_page_size=50)</code>) only changes how many hits are hydrated from DynamoDB per batch. It does not change the S3 Vectors page size (fixed at 100) or time-to-first-result.</p>
 <div class="callout">Reranking and rescoring need the full candidate set, so they are not applied in
 streaming mode. Use <a href="search.html">search()</a> when you need them.</div>
 

--- a/src/dynavec/client.py
+++ b/src/dynavec/client.py
@@ -413,21 +413,32 @@ class Dynavec:
         top_k: int = 50,
         namespace: str = "default",
         filter: Metadata | None = None,
+        page_size: int | None = None,
     ) -> Iterator[SearchResult]:
         """Stream results to the agent page-by-page as S3 Vectors returns them.
 
         A generator: the caller (agent) can start consuming the first hits before
         the full result set is retrieved. Reranking/rescoring are not applied in
         streaming mode (they need the whole candidate set).
+
+        Parameters
+        ----------
+        page_size:
+            Optional client-side chunk size for DynamoDB hydration batches.
+            Defaults to ``DynavecConfig.top_k_page_size``. ``None`` uses native
+            Amazon S3 Vectors pages (at most 100). Yields one hit at a time
+            regardless; this does not change S3 Vectors page size.
         """
         query_vector = self._resolve_query_vector(query, vector)
         yielded = 0
+        effective_page_size = page_size if page_size is not None else self.config.top_k_page_size
         for page in self._vectors.query_pages(
             query_vector=query_vector,
             top_k=top_k,
             filter=build_s3_filter(filter, namespace),
             return_metadata=True,
             return_distance=True,
+            page_size=effective_page_size,
         ):
             page_hits = [(self._split_key(v["key"])[1], v.get("distance")) for v in page]
             hydrated = self._docs.get_many(namespace, [h[0] for h in page_hits])

--- a/src/dynavec/config.py
+++ b/src/dynavec/config.py
@@ -48,6 +48,10 @@ class DynavecConfig:
     over_fetch:
         Multiplier applied to ``top_k`` when reranking is enabled, so the
         reranker has a candidate pool to work with.
+    top_k_page_size:
+        Optional client-side chunk size for streamed query pages. ``None``
+        (default) yields native Amazon S3 Vectors pages (at most 100 vectors).
+        Does not change the service page size.
     """
 
     vector_bucket: str
@@ -65,6 +69,7 @@ class DynavecConfig:
 
     # retrieval tuning
     over_fetch: int = 4
+    top_k_page_size: int | None = None
 
     # concurrency (I/O-bound: threads give real parallelism as boto3 releases
     # the GIL during network calls). See client._executor.
@@ -82,3 +87,5 @@ class DynavecConfig:
             raise ValueError("distance_metric must be 'cosine' or 'euclidean'")
         if self.over_fetch < 1:
             raise ValueError("over_fetch must be >= 1")
+        if self.top_k_page_size is not None and self.top_k_page_size <= 0:
+            raise ValueError("top_k_page_size must be a positive integer")

--- a/src/dynavec/stores/s3vectors.py
+++ b/src/dynavec/stores/s3vectors.py
@@ -21,6 +21,8 @@ Metadata = dict[str, Any]
 # PutVectors accepts up to 500 vectors per call.
 _PUT_LIMIT = 500
 _GET_LIMIT = 100
+# QueryVectors topK maximum (results are returned in pages of at most 100).
+_MAX_TOP_K = 10_000
 
 
 def _f32(vector: list[float]) -> list[float]:
@@ -81,12 +83,25 @@ class S3VectorsStore:
         return_metadata: bool = True,
         return_distance: bool = True,
     ) -> list[dict[str, Any]]:
-        """Run an ANN query. Returns a list of ``{key, distance?, metadata?}``."""
-        kwargs = self._query_kwargs(
-            query_vector, top_k, filter, return_metadata, return_distance
-        )
-        resp = self._client.query_vectors(**kwargs)
-        return resp.get("vectors", [])
+        """Run an ANN query. Drains paginated results up to ``top_k``."""
+        if top_k <= 0:
+            return []
+        if top_k > _MAX_TOP_K:
+            raise ValueError(
+                f"top_k ({top_k}) exceeds Amazon S3 Vectors maximum limit of {_MAX_TOP_K}."
+            )
+        results: list[dict[str, Any]] = []
+        for page in self.query_pages(
+            query_vector,
+            top_k,
+            filter=filter,
+            return_metadata=return_metadata,
+            return_distance=return_distance,
+        ):
+            results.extend(page)
+            if len(results) >= top_k:
+                break
+        return results[:top_k]
 
     def query_pages(
         self,
@@ -95,20 +110,72 @@ class S3VectorsStore:
         filter: Metadata | None = None,
         return_metadata: bool = True,
         return_distance: bool = True,
+        page_size: int | None = None,
     ) -> Iterator[list[dict[str, Any]]]:
         """Yield result **pages** as the S3 Vectors paginator returns them.
 
         This is what powers streaming search: an agent can begin consuming the
         first page while later pages are still in flight.
+
+        Parameters
+        ----------
+        page_size:
+            Optional client-side chunk size for yielded pages. When None (default),
+            yields the raw pages returned by Amazon S3 Vectors (up to 100 per page).
+            This does not change the service page size.
         """
+        if top_k <= 0:
+            return
+        if top_k > _MAX_TOP_K:
+            raise ValueError(
+                f"top_k ({top_k}) exceeds Amazon S3 Vectors maximum limit of {_MAX_TOP_K}."
+            )
+
+        effective_page_size = (
+            page_size if page_size is not None else self._config.top_k_page_size
+        )
+        if effective_page_size is not None and effective_page_size <= 0:
+            raise ValueError("page_size must be a positive integer.")
+
         kwargs = self._query_kwargs(
             query_vector, top_k, filter, return_metadata, return_distance
         )
         paginator = self._client.get_paginator("query_vectors")
-        for page in paginator.paginate(**kwargs):
+        yielded = 0
+        buffer: list[dict[str, Any]] = []
+
+        for page in paginator.paginate(
+            PaginationConfig={"MaxItems": top_k},
+            **kwargs,
+        ):
             vectors = page.get("vectors", [])
-            if vectors:
+            if not vectors:
+                continue
+
+            if effective_page_size is None:
+                remaining = top_k - yielded
+                if len(vectors) > remaining:
+                    vectors = vectors[:remaining]
                 yield vectors
+                yielded += len(vectors)
+                if yielded >= top_k:
+                    return
+            else:
+                buffer.extend(vectors)
+                while len(buffer) >= effective_page_size and yielded < top_k:
+                    chunk = buffer[:effective_page_size]
+                    buffer = buffer[effective_page_size:]
+                    remaining = top_k - yielded
+                    if len(chunk) > remaining:
+                        chunk = chunk[:remaining]
+                    yield chunk
+                    yielded += len(chunk)
+                    if yielded >= top_k:
+                        return
+
+        if effective_page_size is not None and buffer and yielded < top_k:
+            remaining = top_k - yielded
+            yield buffer[:remaining]
 
     @retry()
     def get_vectors(

--- a/tests/test_client_inmemory.py
+++ b/tests/test_client_inmemory.py
@@ -65,11 +65,20 @@ class FakeS3(client_mod.S3VectorsStore):
         scored.sort(key=lambda x: x[1])
         return [{"key": k, "distance": d, "metadata": m} for k, d, m in scored[:top_k]]
 
-    def query_pages(self, query_vector, top_k, filter=None, return_metadata=True, return_distance=True):
+    def query_pages(
+        self,
+        query_vector,
+        top_k,
+        filter=None,
+        return_metadata=True,
+        return_distance=True,
+        page_size=None,
+    ):
         # emulate a paginator: split the result into pages of 2
         hits = self.query(query_vector, top_k, filter, return_metadata, return_distance)
-        for i in range(0, len(hits), 2):
-            yield hits[i : i + 2]
+        chunk_size = page_size or 2
+        for i in range(0, len(hits), chunk_size):
+            yield hits[i : i + chunk_size]
 
     def get_vectors(self, keys, return_metadata=False):
         return {k: {"vector": self._store[k][0], "metadata": self._store[k][1]} for k in keys if k in self._store}

--- a/tests/test_s3vectors.py
+++ b/tests/test_s3vectors.py
@@ -1,5 +1,9 @@
+from unittest.mock import MagicMock
+
+import pytest
+
 from dynavec.config import DynavecConfig
-from dynavec.stores.s3vectors import S3VectorsStore
+from dynavec.stores.s3vectors import _MAX_TOP_K, S3VectorsStore
 
 
 class FakeS3VectorsClient:
@@ -29,3 +33,134 @@ def test_get_vectors_batches_keys_and_merges_results():
 	assert all(call["returnData"] is True for call in fake.calls)
 	assert len(result) == 250
 	assert set(result) == set(keys)
+
+
+def _config(**kwargs):
+	defaults = dict(vector_bucket="test-bucket", index="test-index", table="test-table", dimension=4)
+	defaults.update(kwargs)
+	return DynavecConfig(**defaults)
+
+
+def _store_with_pages(pages, config=None):
+	store = S3VectorsStore.__new__(S3VectorsStore)
+	store._config = config or _config()
+	store._client = MagicMock()
+	paginator = MagicMock()
+	paginator.paginate.return_value = pages
+	store._client.get_paginator.return_value = paginator
+	return store, paginator
+
+
+def test_query_single_page():
+	page = [{"key": f"k{i}", "distance": 0.01 * i} for i in range(50)]
+	store, paginator = _store_with_pages([{"vectors": page}])
+
+	results = store.query(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=50)
+
+	assert len(results) == 50
+	assert results[0]["key"] == "k0"
+	assert results[-1]["key"] == "k49"
+	store._client.get_paginator.assert_called_once_with("query_vectors")
+	assert paginator.paginate.call_args.kwargs["PaginationConfig"] == {"MaxItems": 50}
+	assert paginator.paginate.call_args.kwargs["topK"] == 50
+
+
+def test_query_multi_page_pagination():
+	pages = [
+		{"vectors": [{"key": f"k{i}"} for i in range(100)]},
+		{"vectors": [{"key": f"k{i}"} for i in range(100, 200)]},
+		{"vectors": [{"key": f"k{i}"} for i in range(200, 250)]},
+	]
+	store, paginator = _store_with_pages(pages)
+
+	results = store.query(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=250)
+
+	assert len(results) == 250
+	assert results[0]["key"] == "k0"
+	assert results[99]["key"] == "k99"
+	assert results[100]["key"] == "k100"
+	assert results[249]["key"] == "k249"
+	assert paginator.paginate.call_args.kwargs["PaginationConfig"] == {"MaxItems": 250}
+
+
+def test_query_truncation_at_top_k():
+	pages = [
+		{"vectors": [{"key": f"k{i}"} for i in range(100)]},
+		{"vectors": [{"key": f"k{i}"} for i in range(100, 200)]},
+	]
+	store, _ = _store_with_pages(pages)
+
+	results = store.query(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=130)
+
+	assert len(results) == 130
+	assert results[-1]["key"] == "k129"
+
+
+def test_query_fewer_results_than_top_k():
+	store, _ = _store_with_pages([{"vectors": [{"key": "k0"}, {"key": "k1"}]}])
+
+	results = store.query(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=50)
+
+	assert len(results) == 2
+
+
+def test_query_zero_or_negative_top_k():
+	store, _ = _store_with_pages([{"vectors": [{"key": "k0"}]}])
+
+	assert store.query(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=0) == []
+	assert store.query(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=-5) == []
+	store._client.get_paginator.assert_not_called()
+
+
+def test_query_exceeding_service_limit():
+	store, _ = _store_with_pages([])
+
+	with pytest.raises(ValueError, match="exceeds Amazon S3 Vectors maximum limit"):
+		store.query(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=_MAX_TOP_K + 1)
+
+
+def test_query_pages_raw_chunks():
+	pages = [
+		{"vectors": [{"key": f"k{i}"} for i in range(100)]},
+		{"vectors": [{"key": f"k{i}"} for i in range(100, 150)]},
+	]
+	store, _ = _store_with_pages(pages)
+
+	result_pages = list(store.query_pages(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=150))
+
+	assert [len(p) for p in result_pages] == [100, 50]
+
+
+def test_query_pages_configurable_page_size():
+	store, _ = _store_with_pages(
+		[{"vectors": [{"key": f"k{i}"} for i in range(25)]}]
+	)
+
+	result_pages = list(
+		store.query_pages(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=25, page_size=10)
+	)
+
+	assert [len(p) for p in result_pages] == [10, 10, 5]
+
+
+def test_query_pages_uses_config_top_k_page_size():
+	store, _ = _store_with_pages(
+		[{"vectors": [{"key": f"k{i}"} for i in range(25)]}],
+		config=_config(top_k_page_size=10),
+	)
+
+	result_pages = list(store.query_pages(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=25))
+
+	assert [len(p) for p in result_pages] == [10, 10, 5]
+
+
+def test_query_pages_invalid_page_size():
+	store, _ = _store_with_pages([])
+
+	with pytest.raises(ValueError, match="page_size must be a positive integer"):
+		list(store.query_pages(query_vector=[0.1, 0.2, 0.3, 0.4], top_k=10, page_size=0))
+
+
+def test_config_rejects_non_positive_top_k_page_size():
+	with pytest.raises(ValueError, match="top_k_page_size must be a positive integer"):
+		_config(top_k_page_size=0)

--- a/tools/build_docs.py
+++ b/tools/build_docs.py
@@ -197,6 +197,7 @@ cfg = DynavecConfig(
     region="us-east-1",
     filterable_keys=["topic"],    # metadata keys pushed to S3 Vectors for filtering
     over_fetch=4,                 # candidate multiplier when reranking
+    top_k_page_size=50,           # optional client-side stream batch size
     max_workers=8,                # thread pool for parallel I/O
     auto_provision=True,
 )
@@ -208,6 +209,7 @@ cfg = DynavecConfig(
 <tr><td><code>distance_metric</code></td><td>The S3 Vectors index metric. Other metrics are available at rerank time — see <a href="metrics-and-rerank.html">Metrics</a>.</td></tr>
 <tr><td><code>filterable_keys</code></td><td>Small allowlist of metadata pushed to S3 Vectors. Everything else lives only in DynamoDB. Keep it small.</td></tr>
 <tr><td><code>over_fetch</code></td><td>How many extra candidates to pull before reranking/rescoring.</td></tr>
+<tr><td><code>top_k_page_size</code></td><td>Client-side stream hydration batch. <code>None</code> (default) uses native S3 Vectors pages (at most 100). Does not change the service page size.</td></tr>
 <tr><td><code>max_workers</code>, <code>parallel_writes</code></td><td>Thread-pool <a href="concurrency.html">concurrency</a> controls.</td></tr>
 </table>
 """)
@@ -387,11 +389,13 @@ data isolation, no cross-tenant leakage.</div>
 PAGES["streaming"] = ("Streaming",
     "Deliver results to agents page-by-page as they arrive.",
     """
-<p><code>search_stream()</code> is a generator: it yields hits as S3 Vectors paginates, so an agent can start
-consuming the first results before the full set returns.</p>
-""" + code("""for hit in db.search_stream("large query", top_k=100, namespace="kb"):
-    handle(hit)   # arrives page by page
+<p><code>search_stream()</code> is a generator: it yields one hit at a time as S3 Vectors paginates, so an agent can start
+consuming the first results before the full set returns. Amazon S3 Vectors returns at most 100 vectors per response page;
+dynavec follows <code>nextToken</code> up to the service limit of 10,000 results.</p>
+""" + code("""for hit in db.search_stream("large query", top_k=250, namespace="kb", page_size=50):
+    handle(hit)   # one hit at a time; page_size is the DynamoDB hydration batch
 """) + """
+<p><code>page_size</code> (or <code>DynavecConfig(top_k_page_size=50)</code>) only changes how many hits are hydrated from DynamoDB per batch. It does not change the S3 Vectors page size (fixed at 100) or time-to-first-result.</p>
 <div class="callout">Reranking and rescoring need the full candidate set, so they are not applied in
 streaming mode. Use <a href="search.html">search()</a> when you need them.</div>
 """)


### PR DESCRIPTION
Fixes #16. Supersedes the closed #150 with a smaller diff on current ``development``.

## Problem

``S3VectorsStore.query()`` issued a single ``query_vectors`` call, so results stopped at the first page (100 hits). That silently truncated:

- ``search(..., top_k=250)``
- ``search(..., top_k=50, rerank=mmr)`` which over-fetches ``50 * 4 = 200`` candidates

``search_stream()`` already used the paginator; non-streaming ``search()`` did not.

## Changes

- Drain QueryVectors pages in ``query()`` up to ``top_k``, with ``PaginationConfig={{MaxItems: top_k}}``.
- Enforce the service ceiling of 10,000; ``top_k <= 0`` returns ``[]`` without an API call.
- Add optional ``page_size`` on ``query_pages()`` / ``search_stream()`` and ``DynavecConfig.top_k_page_size``. This is a **client-side DynamoDB hydration batch**, not the S3 Vectors page size (fixed at 100).
- Append unit tests to the existing ``tests/test_s3vectors.py`` (keeps the ``get_vectors`` batch tests).
- Docs via ``tools/build_docs.py`` (streaming + configuration), then regenerated HTML.

## Not in this PR

No ``client.py`` restyle, no ``pythonpath`` / ``.gitignore`` changes.