### PR TITLE
Add Mistral embeddings backend

### DIFF
--- a/opensource/dynavec/docs/embeddings.html
+++ b/opensource/dynavec/docs/embeddings.html
@@ -74,12 +74,14 @@
 <p>Choose an embedder and supply your own API key, or skip the embedder entirely and pass pre-computed vectors.
 Embedder backends are imported lazily, so the base install stays light.</p>
 <pre class="code"><code>from dynavec.embeddings import (
-    OpenAIEmbedder, GeminiEmbedder, BedrockEmbedder, SentenceTransformerEmbedder,
+    OpenAIEmbedder, GeminiEmbedder, MistralEmbedder, BedrockEmbedder,
+    SentenceTransformerEmbedder,
 )
 
 # hosted (BYO key via env var or argument)
 emb = OpenAIEmbedder(model="text-embedding-3-small")        # 1536-d
 emb = GeminiEmbedder(model="text-embedding-004")            # 768-d
+emb = MistralEmbedder(model="mistral-embed")                # 1024-d
 
 # in-account (no third party) or fully local / offline
 emb = BedrockEmbedder(model_id="amazon.titan-embed-text-v2:0", region="us-east-1")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ openai = ["openai>=1.40"]
 gemini = ["google-generativeai>=0.8"]
 cohere = ["cohere>=5.0"]
 voyage = ["voyageai>=0.3.2"]
+mistral = ["mistralai>=2.0"]
 sentence-transformers = ["sentence-transformers>=3.0"]
 # bedrock needs nothing beyond boto3.
 
@@ -56,6 +57,7 @@ all = [
     "google-generativeai>=0.8",
     "cohere>=5.0",
     "voyageai>=0.3.2",
+    "mistralai>=2.0",
     "sentence-transformers>=3.0",
     "redis>=5.0",
     "mcp>=1.0; python_version >= '3.10'",

--- a/src/dynavec/embeddings/__init__.py
+++ b/src/dynavec/embeddings/__init__.py
@@ -14,6 +14,7 @@ from .base import Embedder, Vector
 if TYPE_CHECKING:  # for type checkers / IDEs only
     from .bedrock import BedrockEmbedder
     from .gemini import GeminiEmbedder
+    from .mistral import MistralEmbedder
     from .openai import OpenAIEmbedder
     from .sentence_transformers import SentenceTransformerEmbedder
     from .voyage import VoyageEmbedder
@@ -26,6 +27,7 @@ __all__ = [
     "BedrockEmbedder",
     "SentenceTransformerEmbedder",
     "VoyageEmbedder",
+    "MistralEmbedder",
 ]
 
 _LAZY = {
@@ -37,6 +39,7 @@ _LAZY = {
         "SentenceTransformerEmbedder",
     ),
     "VoyageEmbedder": ("dynavec.embeddings.voyage", "VoyageEmbedder"),
+    "MistralEmbedder": ("dynavec.embeddings.mistral", "MistralEmbedder"),
 }
 
 

--- a/src/dynavec/embeddings/mistral.py
+++ b/src/dynavec/embeddings/mistral.py
@@ -1,0 +1,61 @@
+"""Mistral embedder (bring your own MISTRAL_API_KEY)."""
+
+from __future__ import annotations
+
+from ..exceptions import MissingDependencyError
+from .base import Embedder, Vector
+
+# Known output dimensions for common models (used when dimension is not given).
+_MODEL_DIMS = {
+    "mistral-embed": 1024,
+    "mistral-embed-2312": 1024,
+    "codestral-embed": 1536,
+    "codestral-embed-2505": 1536,
+}
+
+
+class MistralEmbedder(Embedder):
+    """Embeds text with Mistral's embeddings API.
+
+    Parameters
+    ----------
+    model:
+        Model id, e.g. ``"mistral-embed"``.
+    api_key:
+        Optional; falls back to the ``MISTRAL_API_KEY`` environment variable.
+    dimension:
+        Optional override. ``codestral-embed`` supports any size up to 3072 via
+        the API's ``output_dimension`` parameter; ``mistral-embed`` is fixed at
+        1024.
+    batch_size:
+        Texts per request.
+    """
+
+    def __init__(
+        self,
+        model: str = "mistral-embed",
+        api_key: str | None = None,
+        dimension: int | None = None,
+        batch_size: int = 128,
+    ) -> None:
+        try:
+            from mistralai.client import Mistral
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise MissingDependencyError("MistralEmbedder", "mistralai", "mistral") from exc
+
+        self.model = model
+        self._client = Mistral(api_key=api_key)
+        self._requested_dim = dimension
+        self.dimension = dimension or _MODEL_DIMS.get(model, 1024)
+        self.batch_size = batch_size
+
+    def embed_documents(self, texts: list[str]) -> list[Vector]:
+        out: list[Vector] = []
+        for i in range(0, len(texts), self.batch_size):
+            chunk = texts[i : i + self.batch_size]
+            kwargs = {"model": self.model, "inputs": chunk}
+            if self._requested_dim is not None:
+                kwargs["output_dimension"] = self._requested_dim
+            resp = self._client.embeddings.create(**kwargs)
+            out.extend(d.embedding for d in resp.data)
+        return out

--- a/tests/test_mistral_embedder.py
+++ b/tests/test_mistral_embedder.py
@@ -1,0 +1,176 @@
+"""Unit tests for MistralEmbedder.
+
+The ``mistralai`` SDK is an optional extra, so these tests inject a fake module
+into ``sys.modules``: no network, no API key, no dependency on the extra being
+installed.
+"""
+
+import sys
+import types
+
+import pytest
+
+from dynavec.embeddings.mistral import MistralEmbedder
+from dynavec.exceptions import MissingDependencyError
+
+
+def _vec(text, dim):
+    """Deterministic stand-in vector so tests can assert batching order."""
+    return [float(sum(ord(c) for c in text))] * dim
+
+
+class _FakeDatum:
+    def __init__(self, embedding, index):
+        self.embedding = embedding
+        self.index = index
+
+
+class _FakeResponse:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeEmbeddings:
+    """Records every create() call instead of talking to Mistral."""
+
+    def __init__(self):
+        self.calls = []
+
+    def create(self, model=None, inputs=None, output_dimension=None):
+        self.calls.append(
+            {"model": model, "inputs": list(inputs), "output_dimension": output_dimension}
+        )
+        dim = output_dimension or 4
+        return _FakeResponse([_FakeDatum(_vec(t, dim), i) for i, t in enumerate(inputs)])
+
+
+class _FakeMistral:
+    def __init__(self, api_key=None):
+        self.api_key = api_key
+        self.embeddings = _FakeEmbeddings()
+
+
+@pytest.fixture
+def fake_mistralai(monkeypatch):
+    pkg = types.ModuleType("mistralai")
+    client_mod = types.ModuleType("mistralai.client")
+    client_mod.Mistral = _FakeMistral
+    pkg.client = client_mod
+    monkeypatch.setitem(sys.modules, "mistralai", pkg)
+    monkeypatch.setitem(sys.modules, "mistralai.client", client_mod)
+    return client_mod
+
+
+def test_import_does_not_require_the_extra():
+    # Importing the package must not pull in mistralai; the SDK import lives in
+    # __init__ so that this works without `pip install 'dynavec[mistral]'`.
+    assert "mistralai" not in sys.modules
+    from dynavec.embeddings import MistralEmbedder as Exported
+
+    assert Exported is MistralEmbedder
+
+
+def test_missing_dependency_raises(monkeypatch):
+    monkeypatch.setitem(sys.modules, "mistralai", None)  # makes the import fail
+    monkeypatch.setitem(sys.modules, "mistralai.client", None)
+    with pytest.raises(MissingDependencyError) as exc:
+        MistralEmbedder()
+    assert "pip install 'dynavec[mistral]'" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("mistral-embed", 1024),
+        ("mistral-embed-2312", 1024),
+        ("codestral-embed", 1536),
+        ("codestral-embed-2505", 1536),
+    ],
+)
+def test_dimension_from_model_map(fake_mistralai, model, expected):
+    assert MistralEmbedder(model=model).dimension == expected
+
+
+def test_default_model_is_mistral_embed(fake_mistralai):
+    emb = MistralEmbedder()
+    assert emb.model == "mistral-embed"
+    assert emb.dimension == 1024
+
+
+def test_unknown_model_falls_back_to_1024(fake_mistralai):
+    assert MistralEmbedder(model="mistral-embed-does-not-exist").dimension == 1024
+
+
+def test_explicit_dimension_overrides_map_and_is_sent(fake_mistralai):
+    emb = MistralEmbedder(model="codestral-embed", dimension=512)
+    assert emb.dimension == 512
+
+    emb.embed_documents(["a"])
+    assert emb._client.embeddings.calls[0]["output_dimension"] == 512
+
+
+def test_output_dimension_omitted_when_not_requested(fake_mistralai):
+    emb = MistralEmbedder()
+    emb.embed_documents(["a"])
+    assert emb._client.embeddings.calls[0]["output_dimension"] is None
+
+
+def test_api_key_is_passed_through(fake_mistralai):
+    assert MistralEmbedder(api_key="sk-test")._client.api_key == "sk-test"
+
+
+def test_api_key_defers_to_env_var_when_omitted(fake_mistralai):
+    # Passing None lets the SDK read MISTRAL_API_KEY itself.
+    assert MistralEmbedder()._client.api_key is None
+
+
+def test_embed_documents_sends_texts_as_inputs(fake_mistralai):
+    emb = MistralEmbedder()
+    out = emb.embed_documents(["alpha", "beta"])
+
+    assert out == [_vec("alpha", 4), _vec("beta", 4)]
+    assert emb._client.embeddings.calls == [
+        {"model": "mistral-embed", "inputs": ["alpha", "beta"], "output_dimension": None}
+    ]
+
+
+def test_embed_query_returns_a_single_vector(fake_mistralai):
+    # Mistral has no asymmetric query mode, so the base-class default applies.
+    emb = MistralEmbedder()
+    assert emb.embed_query("alpha") == _vec("alpha", 4)
+    assert emb._client.embeddings.calls[0]["inputs"] == ["alpha"]
+
+
+def test_batching_splits_requests_and_preserves_order(fake_mistralai):
+    texts = ["a", "b", "c", "d", "e"]
+    emb = MistralEmbedder(batch_size=2)
+    out = emb.embed_documents(texts)
+
+    assert [c["inputs"] for c in emb._client.embeddings.calls] == [
+        ["a", "b"],
+        ["c", "d"],
+        ["e"],
+    ]
+    assert out == [_vec(t, 4) for t in texts]
+
+
+def test_empty_input_makes_no_requests(fake_mistralai):
+    emb = MistralEmbedder()
+    assert emb.embed_documents([]) == []
+    assert emb._client.embeddings.calls == []
+
+
+def test_api_errors_propagate(fake_mistralai):
+    class _Boom(_FakeMistral):
+        def __init__(self, api_key=None):
+            super().__init__(api_key=api_key)
+
+            def _raise(**kwargs):
+                raise RuntimeError("rate limited")
+
+            self.embeddings.create = _raise
+
+    fake_mistralai.Mistral = _Boom
+    emb = MistralEmbedder()
+    with pytest.raises(RuntimeError, match="rate limited"):
+        emb.embed_documents(["a"])

--- a/tools/build_docs.py
+++ b/tools/build_docs.py
@@ -220,12 +220,14 @@ PAGES["embeddings"] = ("Embeddings",
 <p>Choose an embedder and supply your own API key, or skip the embedder entirely and pass pre-computed vectors.
 Embedder backends are imported lazily, so the base install stays light.</p>
 """ + code("""from dynavec.embeddings import (
-    OpenAIEmbedder, GeminiEmbedder, BedrockEmbedder, SentenceTransformerEmbedder,
+    OpenAIEmbedder, GeminiEmbedder, MistralEmbedder, BedrockEmbedder,
+    SentenceTransformerEmbedder,
 )
 
 # hosted (BYO key via env var or argument)
 emb = OpenAIEmbedder(model="text-embedding-3-small")        # 1536-d
 emb = GeminiEmbedder(model="text-embedding-004")            # 768-d
+emb = MistralEmbedder(model="mistral-embed")                # 1024-d
 
 # in-account (no third party) or fully local / offline
 emb = BedrockEmbedder(model_id="amazon.titan-embed-text-v2:0", region="us-east-1")


### PR DESCRIPTION
Adds MistralEmbedder alongside the existing OpenAI / Gemini / Voyage / Bedrock / sentence-transformers backends, following the same lazy-import pattern: `from mistralai.client import Mistral` happens inside __init__ and raises MissingDependencyError pointing at the new `mistral` extra, so `from dynavec.embeddings import ...` keeps working without it installed.

- Dimension map for mistral-embed (1024) and codestral-embed (1536) plus their dated aliases; unknown models fall back to 1024.
- `dimension` override is forwarded as the API's `output_dimension` (codestral-embed is flexible up to 3072; mistral-embed is fixed at 1024).
- Mistral has no asymmetric query mode, so embed_query keeps the base-class default instead of overriding it.
- Docs: MistralEmbedder added to the embeddings page snippet in tools/build_docs.py, with opensource/dynavec/docs/embeddings.html regenerated from it.
- Tests mock the SDK via sys.modules: no network, no API key, and no need for the extra to be installed.

Closes #4