### PR TITLE
test: cover graph traversal cycles

### DIFF
--- a/tests/test_client_inmemory.py
+++ b/tests/test_client_inmemory.py
@@ -365,6 +365,14 @@ def test_graph_traversal_hops(db):
     assert {h.id for h in hits} == {"d1"}
 
 
+def test_graph_traversal_handles_cycles(db):
+    db.graph_add_edge("a", "related_to", "b")
+    db.graph_add_edge("b", "related_to", "c")
+    db.graph_add_edge("c", "related_to", "a")
+
+    assert set(db.graph_neighbors("a", hops=10)) == {"b", "c"}
+
+
 def test_semantic_cache_hits_on_repeat(db):
     from dynavec.cache import SemanticCache
 


### PR DESCRIPTION
## Summary

Adds regression coverage for graph traversal when the graph contains a cycle.

The test verifies that traversal:

- Handles a cycle such as `a -> b -> c -> a`
- Terminates without looping indefinitely
- Returns reachable nodes without including the starting node

## Testing

- `uv run --no-sync pytest tests/test_client_inmemory.py -q`
- `uv run --no-sync ruff check src tests`
- `uv run --no-sync pytest -q`

Closes #34