### PR TITLE
fix(packaging): update stale project.urls placeholder to codeforstartups/dynavec (#156)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,9 +79,9 @@ benchmark = [
 
 
 [project.urls]
-Homepage = "https://github.com/your-org/dynavec"
-Documentation = "https://github.com/your-org/dynavec#readme"
-Issues = "https://github.com/your-org/dynavec/issues"
+Homepage = "https://github.com/codeforstartups/dynavec"
+Documentation = "https://github.com/codeforstartups/dynavec#readme"
+Issues = "https://github.com/codeforstartups/dynavec/issues"
 
 [project.scripts]
 dynavec = "dynavec.cli:main"


### PR DESCRIPTION
Closes #156

### Description
Updates placeholder `your-org` URLs under `[project.urls]` in `pyproject.toml` to point to `codeforstartups/dynavec` so that PyPI package metadata links (Homepage, Documentation, Issues) resolve correctly.

### Verification
- Scanned repository to confirm no remaining instances of `your-org`.
- Ran full test suite via `pytest` (all 114 tests passing).
