### PR TITLE
ci: add Python 3.13 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.9", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Install uv


### PR DESCRIPTION
Closes #114

### Summary
Adds Python 3.13 to the GitHub Actions test matrix in `ci.yml` alongside the existing Python 3.9, 3.11, and 3.12 jobs.

### Acceptance Criteria Covered
- [x] Python 3.13 matrix entry added to `.github/workflows/ci.yml`
- [x] Test suite passing cleanly on Python 3.13

### Local Verification
- **Pytest**: Ran full test suite locally against Python 3.13.7:
  `114 passed, 2 skipped in 23.92s`
- **Linting**: Checked with `ruff check src benchmarks tests`:
  `All checks passed!`
