### PR TITLE
test(s3vectors): add table-driven operator tests for build_s3_filter

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,5 +1,7 @@
 """Tests for metadata splitting / auto-generation / filter building."""
 
+import pytest
+
 from dynavec.config import NS_METADATA_KEY, TEXT_METADATA_KEY, DynavecConfig
 from dynavec.metadata import (
     build_s3_filter,
@@ -48,15 +50,157 @@ def test_split_text_mirror_optional():
     assert s3[TEXT_METADATA_KEY] == "abcde"
 
 
-def test_build_filter_wraps_with_namespace():
-    f = build_s3_filter({"genre": "scifi"}, "ns1")
-    assert f == {"$and": [{"genre": "scifi"}, {NS_METADATA_KEY: "ns1"}]}
+@pytest.mark.parametrize(
+    ("user_filter", "namespace", "expected"),
+    [
+        # None and empty filter
+        (None, "default", {NS_METADATA_KEY: "default"}),
+        ({}, "production", {NS_METADATA_KEY: "production"}),
+        # Bare equality
+        (
+            {"genre": "scifi"},
+            "ns1",
+            {"$and": [{"genre": "scifi"}, {NS_METADATA_KEY: "ns1"}]},
+        ),
+        # $eq operator
+        (
+            {"status": {"$eq": "active"}},
+            "ns_app",
+            {"$and": [{"status": {"$eq": "active"}}, {NS_METADATA_KEY: "ns_app"}]},
+        ),
+        # $ne operator
+        (
+            {"archived": {"$ne": True}},
+            "ns_v1",
+            {"$and": [{"archived": {"$ne": True}}, {NS_METADATA_KEY: "ns_v1"}]},
+        ),
+        # Numeric comparison operators ($gte, $gt, $lte, $lt)
+        (
+            {"rating": {"$gte": 4.5}},
+            "catalog",
+            {"$and": [{"rating": {"$gte": 4.5}}, {NS_METADATA_KEY: "catalog"}]},
+        ),
+        (
+            {"price": {"$lt": 50.0}},
+            "catalog",
+            {"$and": [{"price": {"$lt": 50.0}}, {NS_METADATA_KEY: "catalog"}]},
+        ),
+        (
+            {"score": {"$gt": 0.8}, "views": {"$lte": 1000}},
+            "analytics",
+            {
+                "$and": [
+                    {"score": {"$gt": 0.8}, "views": {"$lte": 1000}},
+                    {NS_METADATA_KEY: "analytics"},
+                ]
+            },
+        ),
+        # $in and $nin operators
+        (
+            {"tag": {"$in": ["python", "aws", "vector"]}},
+            "dev",
+            {
+                "$and": [
+                    {"tag": {"$in": ["python", "aws", "vector"]}},
+                    {NS_METADATA_KEY: "dev"},
+                ]
+            },
+        ),
+        (
+            {"role": {"$nin": ["guest", "banned"]}},
+            "users",
+            {
+                "$and": [
+                    {"role": {"$nin": ["guest", "banned"]}},
+                    {NS_METADATA_KEY: "users"},
+                ]
+            },
+        ),
+        # $or operator combinations
+        (
+            {"$or": [{"category": "news"}, {"category": "tech"}]},
+            "media",
+            {
+                "$and": [
+                    {"$or": [{"category": "news"}, {"category": "tech"}]},
+                    {NS_METADATA_KEY: "media"},
+                ]
+            },
+        ),
+        (
+            {"$or": [{"price": {"$gte": 100}}, {"rating": {"$gte": 4.8}}]},
+            "products",
+            {
+                "$and": [
+                    {"$or": [{"price": {"$gte": 100}}, {"rating": {"$gte": 4.8}}]},
+                    {NS_METADATA_KEY: "products"},
+                ]
+            },
+        ),
+        (
+            {
+                "$or": [
+                    {"category": {"$in": ["electronics", "computers"]}},
+                    {"discount": {"$gte": 0.2}},
+                ]
+            },
+            "store",
+            {
+                "$and": [
+                    {
+                        "$or": [
+                            {"category": {"$in": ["electronics", "computers"]}},
+                            {"discount": {"$gte": 0.2}},
+                        ]
+                    },
+                    {NS_METADATA_KEY: "store"},
+                ]
+            },
+        ),
+        # Top-level $and list extension (should not double wrap)
+        (
+            {"$and": [{"a": 1}]},
+            "ns1",
+            {"$and": [{"a": 1}, {NS_METADATA_KEY: "ns1"}]},
+        ),
+        (
+            {
+                "$and": [
+                    {"rating": {"$gte": 4.0}},
+                    {"tag": {"$in": ["featured", "trending"]}},
+                ]
+            },
+            "catalog",
+            {
+                "$and": [
+                    {"rating": {"$gte": 4.0}},
+                    {"tag": {"$in": ["featured", "trending"]}},
+                    {NS_METADATA_KEY: "catalog"},
+                ]
+            },
+        ),
+        # Complex nested $and + $or + $in + $gte combinations
+        (
+            {
+                "$and": [
+                    {"$or": [{"tier": "premium"}, {"tier": "vip"}]},
+                    {"spend": {"$gte": 500}},
+                    {"country": {"$in": ["US", "CA", "UK"]}},
+                ]
+            },
+            "customers",
+            {
+                "$and": [
+                    {"$or": [{"tier": "premium"}, {"tier": "vip"}]},
+                    {"spend": {"$gte": 500}},
+                    {"country": {"$in": ["US", "CA", "UK"]}},
+                    {NS_METADATA_KEY: "customers"},
+                ]
+            },
+        ),
+    ],
+)
+def test_build_s3_filter_operator_combinations(user_filter, namespace, expected):
+    """Table-driven tests covering $and, $or, $in, $gte and other operators."""
+    assert build_s3_filter(user_filter, namespace) == expected
 
-
-def test_build_filter_none():
-    assert build_s3_filter(None, "ns1") == {NS_METADATA_KEY: "ns1"}
-
-
-def test_build_filter_extends_existing_and():
-    f = build_s3_filter({"$and": [{"a": 1}]}, "ns1")
-    assert f == {"$and": [{"a": 1}, {NS_METADATA_KEY: "ns1"}]}


### PR DESCRIPTION
Closes #92

### Summary
Adds comprehensive table-driven tests for `build_s3_filter` covering combinations of `$and`, `$or`, `$in`, `$nin`, `$gte`, `$gt`, `$lte`, `$lt`, `$eq`, `$ne`, and nested logical expressions.

### Acceptance Criteria Covered
- [x] Table-driven tests using `pytest.mark.parametrize`
- [x] Covers `$and`, `$or`, `$in`, `$gte` combinations and edge cases (empty filter, None)

### Verification
- Ran `pytest tests/test_metadata.py -v`: 20 passed.
- Ran full test suite `pytest`: 127 passed, 2 skipped.
- Ran `ruff check src benchmarks tests`: All checks passed.
