### PR TITLE
fix(packaging): pin crewai away from yanked 1.14.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ ingest = ["pypdf>=4.0", "python-docx>=1.1", "python-pptx>=0.6", "openpyxl>=3.1"]
 # --- Agent framework integrations ---
 langchain = ["langchain-core>=0.3"]
 llamaindex = ["llama-index-core>=0.11"]
-crewai = ["crewai>=0.70; python_version >= '3.10'"]
+crewai = ["crewai>=0.70,!=1.14.0; python_version >= '3.10'"]
 all = [
     "openai>=1.40",
     "google-generativeai>=0.8",
@@ -61,7 +61,7 @@ all = [
     "mcp>=1.0; python_version >= '3.10'",
     "langchain-core>=0.3",
     "llama-index-core>=0.11",
-    "crewai>=0.70; python_version >= '3.10'",
+    "crewai>=0.70,!=1.14.0; python_version >= '3.10'",
 ]
 
 # --- Dev / test / benchmark ---


### PR DESCRIPTION
Closes #110

### Summary of Changes
- Updated `crewai` and `all` optional dependency specifications in `pyproject.toml` to exclude the yanked `1.14.0` release (`crewai>=0.70,!=1.14.0; python_version >= '3.10'`).
- Ensures `dynavec[all]` and `dynavec[crewai]` resolve cleanly across Python 3.10+ environments.

### Verification
- **Packaging specifier test**: Validated via `packaging.requirements` and `packaging.version` that `1.14.0` is strictly rejected while `0.70.0+` and subsequent patch releases are allowed.
- **Live resolver dry-run**: Verified `pip install --dry-run -e ".[crewai]"` resolves cleanly without conflicts.
- **Test suite**: Full `pytest` suite passed (114 passed, 2 skipped).
- **Linter**: `ruff check pyproject.toml` passed with zero errors.
