### PR TITLE
feat: ship FastMCP server for semantic and graph search (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,35 @@ store = DynavecVectorStore(db, namespace="kb")
 retriever = store.as_retriever(search_kwargs={"k": 4})
 ```
 
+### FastMCP Server (Claude Desktop, Cursor, AI agents)
+
+Expose `dynavec_search` and `dynavec_graph_search` tools to any MCP client over stdio:
+
+```bash
+# Launch MCP server from environment variables
+dynavec mcp
+```
+
+```json
+{
+  "mcpServers": {
+    "dynavec": {
+      "command": "uvx",
+      "args": ["--with", "dynavec[all]", "dynavec", "mcp"],
+      "env": {
+        "AWS_ACCESS_KEY_ID": "AKIA...",
+        "AWS_SECRET_ACCESS_KEY": "...",
+        "AWS_REGION": "us-east-1",
+        "OPENAI_API_KEY": "sk-...",
+        "DYNAVEC_VECTOR_BUCKET": "my-vectors",
+        "DYNAVEC_INDEX": "docs",
+        "DYNAVEC_TABLE": "dynavec_docs"
+      }
+    }
+  }
+}
+```
+
 LlamaIndex, CrewAI, and Strands adapters are on the roadmap; the core client works in any of them today.
 
 ---

--- a/examples/mcp_server_config.json
+++ b/examples/mcp_server_config.json
@@ -1,0 +1,25 @@
+{
+  "mcpServers": {
+    "dynavec": {
+      "command": "uvx",
+      "args": [
+        "--with",
+        "dynavec[all]",
+        "dynavec",
+        "mcp"
+      ],
+      "env": {
+        "AWS_ACCESS_KEY_ID": "AKIA...YOUR_AWS_KEY...",
+        "AWS_SECRET_ACCESS_KEY": "...YOUR_AWS_SECRET...",
+        "AWS_REGION": "us-east-1",
+        "OPENAI_API_KEY": "sk-...YOUR_OPENAI_KEY...",
+        "DYNAVEC_VECTOR_BUCKET": "my-vectors",
+        "DYNAVEC_INDEX": "docs",
+        "DYNAVEC_TABLE": "dynavec_docs",
+        "DYNAVEC_DIMENSION": "1536",
+        "DYNAVEC_EMBEDDER": "openai"
+      }
+    }
+  }
+}
+

--- a/opensource/dynavec/docs/integrations.html
+++ b/opensource/dynavec/docs/integrations.html
@@ -88,6 +88,36 @@ index = VectorStoreIndex.from_documents(docs, storage_context=ctx)</code></pre>
 <pre class="code"><code>from dynavec.integrations.tools import make_retriever_fn
 retrieve = make_retriever_fn(db, top_k=4)   # fn(query: str) -> str
 # also: as_langchain_tool(db), as_crewai_tool(db)</code></pre>
+<h2>FastMCP server (Claude Desktop, Cursor, AI agents)</h2>
+<p>Expose dynavec as an MCP server with <code>dynavec_search</code> and <code>dynavec_graph_search</code> tools. Configure via environment variables and launch over stdio:</p>
+<pre class="code"><code># Install with MCP extra
+pip install "dynavec[mcp]"
+
+# Launch the FastMCP server via CLI
+dynavec mcp</code></pre>
+<p>Add to your Claude Desktop / Cursor configuration (<code>claude_desktop_config.json</code>):</p>
+<pre class="code"><code>{
+  "mcpServers": {
+    "dynavec": {
+      "command": "uvx",
+      "args": ["--with", "dynavec[all]", "dynavec", "mcp"],
+      "env": {
+        "AWS_ACCESS_KEY_ID": "AKIA...",
+        "AWS_SECRET_ACCESS_KEY": "...",
+        "AWS_REGION": "us-east-1",
+        "OPENAI_API_KEY": "sk-...",
+        "DYNAVEC_VECTOR_BUCKET": "my-vectors",
+        "DYNAVEC_INDEX": "docs",
+        "DYNAVEC_TABLE": "dynavec_docs"
+      }
+    }
+  }
+}</code></pre>
+<p>Programmatic initialization is also supported:</p>
+<pre class="code"><code>from dynavec.mcp import create_mcp_server
+
+mcp = create_mcp_server(db)
+mcp.run(transport="stdio")</code></pre>
       <div class="doc__next"><a href="credentials.html"><span>Previous</span>Credentials & IAM</a><a href="benchmarking.html" style="text-align:right"><span>Next</span>Benchmarking</a></div>
     </main>
   </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ openai = ["openai>=1.40"]
 gemini = ["google-generativeai>=0.8"]
 cohere = ["cohere>=5.0"]
 voyage = ["voyageai>=0.3.2"]
-mistral = ["mistralai>=2.0"]
+mistral = ["mistralai>=2.0; python_version >= '3.10'"]
 sentence-transformers = ["sentence-transformers>=3.0"]
 # bedrock needs nothing beyond boto3.
 
@@ -57,7 +57,7 @@ all = [
     "google-generativeai>=0.8",
     "cohere>=5.0",
     "voyageai>=0.3.2",
-    "mistralai>=2.0",
+    "mistralai>=2.0; python_version >= '3.10'",
     "sentence-transformers>=3.0",
     "redis>=5.0",
     "mcp>=1.0; python_version >= '3.10'",

--- a/src/dynavec/cli.py
+++ b/src/dynavec/cli.py
@@ -15,6 +15,20 @@ def _parser() -> argparse.ArgumentParser:
 	doctor.add_argument("--table", help="DynamoDB table name")
 	doctor.add_argument("--region", help="AWS region")
 	doctor.add_argument("--profile", help="AWS profile name")
+
+	mcp = subparsers.add_parser("mcp", help="run the FastMCP server for AI clients")
+	mcp.add_argument(
+		"--transport",
+		choices=["stdio", "sse"],
+		default="stdio",
+		help="Transport mode (default: stdio)",
+	)
+	mcp.add_argument(
+		"--port",
+		type=int,
+		default=8000,
+		help="Port for SSE transport (default: 8000)",
+	)
 	return parser
 
 
@@ -97,6 +111,16 @@ def main(argv: list[str] | None = None) -> int:
 	args = _parser().parse_args(argv)
 	if args.command == "doctor":
 		return _doctor(args)
+	if args.command == "mcp":
+		from .mcp.server import create_mcp_server
+
+		server = create_mcp_server()
+		if args.transport == "sse":
+			server.settings.port = args.port
+			server.run(transport="sse")
+		else:
+			server.run(transport="stdio")
+		return 0
 	_parser().print_help()
 	return 0
 

--- a/src/dynavec/mcp/__init__.py
+++ b/src/dynavec/mcp/__init__.py
@@ -1,0 +1,12 @@
+"""Model Context Protocol (MCP) server for dynavec.
+
+Allows any MCP client (Claude Desktop, Cursor, Antigravity, custom agents)
+to query dynavec over FastMCP tools.
+"""
+
+from __future__ import annotations
+
+from .server import client_from_env, create_mcp_server, main
+
+__all__ = ["client_from_env", "create_mcp_server", "main"]
+

--- a/src/dynavec/mcp/server.py
+++ b/src/dynavec/mcp/server.py
@@ -27,6 +27,8 @@ def _resolve_embedder(env: Mapping[str, str]):
             embedder_type = "gemini"
         elif env.get("VOYAGE_API_KEY"):
             embedder_type = "voyage"
+        elif env.get("MISTRAL_API_KEY"):
+            embedder_type = "mistral"
 
     if not embedder_type or embedder_type in ("none", "false", "0"):
         return None
@@ -46,6 +48,10 @@ def _resolve_embedder(env: Mapping[str, str]):
         from ..embeddings.voyage import VoyageEmbedder
 
         return VoyageEmbedder(model=model or "voyage-4", api_key=env.get("VOYAGE_API_KEY"))
+    if embedder_type == "mistral":
+        from ..embeddings.mistral import MistralEmbedder
+
+        return MistralEmbedder(model=model or "mistral-embed", api_key=env.get("MISTRAL_API_KEY"))
     if embedder_type == "bedrock":
         from ..embeddings.bedrock import BedrockEmbedder
 

--- a/src/dynavec/mcp/server.py
+++ b/src/dynavec/mcp/server.py
@@ -1,0 +1,239 @@
+"""FastMCP server exposing dynavec search and GraphRAG to MCP clients."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Mapping
+from typing import Any
+
+from ..client import Dynavec
+from ..config import DynavecConfig
+from ..exceptions import ConfigurationError, MissingDependencyError
+
+
+def _resolve_embedder(env: Mapping[str, str]):
+    """Instantiate an embedder from environment variables or return None."""
+    embedder_type = (env.get("DYNAVEC_EMBEDDER") or "").strip().lower()
+    model = env.get("DYNAVEC_EMBEDDER_MODEL")
+
+    # Auto-detect if not explicitly set
+    if not embedder_type:
+        if env.get("OPENAI_API_KEY"):
+            embedder_type = "openai"
+        elif env.get("GOOGLE_API_KEY") or env.get("GEMINI_API_KEY"):
+            embedder_type = "gemini"
+        elif env.get("VOYAGE_API_KEY"):
+            embedder_type = "voyage"
+
+    if not embedder_type or embedder_type in ("none", "false", "0"):
+        return None
+
+    if embedder_type == "openai":
+        from ..embeddings.openai import OpenAIEmbedder
+
+        return OpenAIEmbedder(model=model or "text-embedding-3-small", api_key=env.get("OPENAI_API_KEY"))
+    if embedder_type == "gemini":
+        from ..embeddings.gemini import GeminiEmbedder
+
+        return GeminiEmbedder(
+            model=model or "text-embedding-004",
+            api_key=env.get("GOOGLE_API_KEY") or env.get("GEMINI_API_KEY"),
+        )
+    if embedder_type == "voyage":
+        from ..embeddings.voyage import VoyageEmbedder
+
+        return VoyageEmbedder(model=model or "voyage-4", api_key=env.get("VOYAGE_API_KEY"))
+    if embedder_type == "bedrock":
+        from ..embeddings.bedrock import BedrockEmbedder
+
+        region = env.get("DYNAVEC_REGION") or env.get("AWS_REGION") or env.get("AWS_DEFAULT_REGION")
+        return BedrockEmbedder(model_id=model or "amazon.titan-embed-text-v2:0", region=region)
+    if embedder_type in ("sentence-transformers", "local"):
+        from ..embeddings.sentence_transformers import SentenceTransformerEmbedder
+
+        return SentenceTransformerEmbedder(model=model or "all-MiniLM-L6-v2")
+
+    raise ConfigurationError(f"Unknown embedder type: '{embedder_type}'")
+
+
+def client_from_env(env: Mapping[str, str] | None = None) -> Dynavec:
+    """Build a Dynavec client configured from environment variables."""
+    e = env if env is not None else os.environ
+
+    bucket = e.get("DYNAVEC_VECTOR_BUCKET") or e.get("DYNAVEC_BUCKET")
+    index = e.get("DYNAVEC_INDEX")
+    table = e.get("DYNAVEC_TABLE")
+
+    missing = []
+    if not bucket:
+        missing.append("DYNAVEC_VECTOR_BUCKET (or DYNAVEC_BUCKET)")
+    if not index:
+        missing.append("DYNAVEC_INDEX")
+    if not table:
+        missing.append("DYNAVEC_TABLE")
+    if missing:
+        raise ConfigurationError(f"Missing required environment variable(s): {', '.join(missing)}")
+
+    embedder = _resolve_embedder(e)
+
+    dim_raw = e.get("DYNAVEC_DIMENSION")
+    if dim_raw:
+        dimension = int(dim_raw)
+    elif embedder is not None and getattr(embedder, "dimension", None):
+        dimension = int(embedder.dimension)
+    else:
+        dimension = 1536
+
+    fk_raw = e.get("DYNAVEC_FILTERABLE_KEYS")
+    filterable_keys = [k.strip() for k in fk_raw.split(",") if k.strip()] if fk_raw else None
+
+    region = e.get("DYNAVEC_REGION") or e.get("AWS_REGION") or e.get("AWS_DEFAULT_REGION")
+    distance_metric = e.get("DYNAVEC_DISTANCE_METRIC", "cosine")
+
+    cfg = DynavecConfig(
+        vector_bucket=str(bucket),
+        index=str(index),
+        table=str(table),
+        dimension=dimension,
+        distance_metric=distance_metric,  # type: ignore[arg-type]
+        region=region,
+        filterable_keys=filterable_keys,
+    )
+    return Dynavec(cfg, embedder=embedder)
+
+
+def _format_hits(hits: list[Any], query: str, context_label: str = "") -> str:
+    """Format search results into human/agent readable text."""
+    if not hits:
+        return f"No results found for query '{query}'{context_label}."
+
+    lines = [f"Found {len(hits)} results for query '{query}'{context_label}:\n"]
+    for i, h in enumerate(hits, 1):
+        meta_str = f" | metadata: {json.dumps(h.metadata, default=str)}" if h.metadata else ""
+        lines.append(f"[{i}] id: {h.id} (score: {h.score:.4f}{meta_str})\n{h.text or ''}\n")
+    return "\n".join(lines).strip()
+
+
+def create_mcp_server(db: Dynavec | None = None, name: str = "dynavec"):
+    """Create and configure a FastMCP server exposing dynavec search and graph search tools."""
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ImportError as exc:  # pragma: no cover
+        raise MissingDependencyError("create_mcp_server", "mcp", "mcp") from exc
+
+    mcp = FastMCP(name)
+
+    def _get_db() -> Dynavec:
+        return db if db is not None else client_from_env()
+
+    @mcp.tool()
+    def dynavec_search(
+        query: str,
+        top_k: int = 5,
+        namespace: str = "default",
+        filter_json: str | None = None,
+        rescore: str | None = None,
+        rerank: str | None = None,
+    ) -> str:
+        """Search the dynavec vector database for semantic similarity.
+
+        Parameters
+        ----------
+        query:
+            Natural language query text.
+        top_k:
+            Number of matching documents to retrieve (default: 5).
+        namespace:
+            Tenant or collection namespace (default: "default").
+        filter_json:
+            Optional JSON string for metadata pre-filtering (e.g. '{"topic": "tech"}').
+        rescore:
+            Optional rescoring metric ("cosine", "dot", "euclidean", "manhattan").
+        rerank:
+            Optional reranking strategy (e.g. "mmr" for diversity).
+        """
+        filter_dict = None
+        if filter_json:
+            try:
+                filter_dict = json.loads(filter_json)
+            except Exception as exc:
+                return f"Error parsing filter_json: {exc}"
+
+        client = _get_db()
+        hits = client.search(
+            query=query,
+            top_k=top_k,
+            namespace=namespace,
+            filter=filter_dict,
+            rescore=rescore,
+            rerank=rerank,
+        )
+        return _format_hits(hits, query, f" in namespace '{namespace}'")
+
+    @mcp.tool()
+    def dynavec_graph_search(
+        query: str,
+        seed_entities: list[str],
+        hops: int = 2,
+        top_k: int = 5,
+        namespace: str = "default",
+    ) -> str:
+        """Perform GraphRAG search by traversing related entities before vector ranking.
+
+        Parameters
+        ----------
+        query:
+            Search query to rank documents associated with traversed entities.
+        seed_entities:
+            List of starting entity IDs for the graph traversal.
+        hops:
+            Number of relationship hops to traverse from seed entities (default: 2).
+        top_k:
+            Number of documents to return (default: 5).
+        namespace:
+            Tenant or collection namespace (default: "default").
+        """
+        client = _get_db()
+        hits = client.graph_search(
+            query=query,
+            seed_entities=seed_entities,
+            hops=hops,
+            top_k=top_k,
+            namespace=namespace,
+        )
+        return _format_hits(hits, query, f" (seeds: {seed_entities}, hops: {hops})")
+
+    return mcp
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the FastMCP server with stdio or SSE transport."""
+    parser = argparse.ArgumentParser(prog="dynavec mcp", description="Run the dynavec FastMCP server.")
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "sse"],
+        default="stdio",
+        help="Transport mode (default: stdio)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port for SSE transport (default: 8000)",
+    )
+    args = parser.parse_args(argv)
+
+    server = create_mcp_server()
+    if args.transport == "sse":
+        server.settings.port = args.port
+        server.run(transport="sse")
+    else:
+        server.run(transport="stdio")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,219 @@
+"""Unit tests for FastMCP server and environment-based client configuration."""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from dynavec.cli import _parser
+from dynavec.exceptions import ConfigurationError, MissingDependencyError
+from dynavec.mcp.server import client_from_env, create_mcp_server
+from dynavec.models import SearchResult
+
+
+class _FakeTool:
+    def __init__(self, fn, name=None, description=None):
+        self.fn = fn
+        self.name = name or fn.__name__
+        self.description = description or fn.__doc__
+
+
+class _FakeFastMCP:
+    """Mock FastMCP object capturing registered tools."""
+
+    def __init__(self, name="dynavec", **kwargs):
+        self.name = name
+        self.tools = {}
+        self.settings = types.SimpleNamespace(port=8000)
+
+    def tool(self, name=None, description=None):
+        def decorator(fn):
+            tool_obj = _FakeTool(fn, name=name, description=description)
+            self.tools[tool_obj.name] = tool_obj
+            return fn
+
+        return decorator
+
+    def run(self, transport="stdio"):
+        self.last_transport = transport
+
+
+@pytest.fixture
+def fake_mcp(monkeypatch):
+    """Inject a fake mcp.server.fastmcp module into sys.modules."""
+    mcp_mod = types.ModuleType("mcp")
+    server_mod = types.ModuleType("mcp.server")
+    fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    fastmcp_mod.FastMCP = _FakeFastMCP
+
+    monkeypatch.setitem(sys.modules, "mcp", mcp_mod)
+    monkeypatch.setitem(sys.modules, "mcp.server", server_mod)
+    monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", fastmcp_mod)
+    return fastmcp_mod
+
+
+def test_missing_mcp_dependency_raises(monkeypatch):
+    monkeypatch.setitem(sys.modules, "mcp", None)
+    monkeypatch.setitem(sys.modules, "mcp.server", None)
+    monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", None)
+
+    with pytest.raises(MissingDependencyError) as exc:
+        create_mcp_server()
+    assert "pip install 'dynavec[mcp]'" in str(exc.value)
+
+
+def test_client_from_env_missing_required():
+    with pytest.raises(ConfigurationError, match="Missing required environment variable"):
+        client_from_env({})
+
+    with pytest.raises(ConfigurationError, match="DYNAVEC_INDEX"):
+        client_from_env({"DYNAVEC_VECTOR_BUCKET": "b", "DYNAVEC_TABLE": "t"})
+
+
+def test_client_from_env_full_configuration(monkeypatch):
+    import dynavec.embeddings.openai as oai_mod
+
+    mock_oai = MagicMock()
+    mock_oai.dimension = 1536
+    monkeypatch.setattr(oai_mod, "OpenAIEmbedder", lambda **kw: mock_oai)
+
+    env = {
+        "DYNAVEC_VECTOR_BUCKET": "my-bucket",
+        "DYNAVEC_INDEX": "my-index",
+        "DYNAVEC_TABLE": "my-table",
+        "DYNAVEC_DIMENSION": "1536",
+        "DYNAVEC_REGION": "us-west-2",
+        "DYNAVEC_FILTERABLE_KEYS": "topic, category",
+        "DYNAVEC_DISTANCE_METRIC": "euclidean",
+        "OPENAI_API_KEY": "sk-test",
+    }
+    client = client_from_env(env)
+    assert client.config.vector_bucket == "my-bucket"
+    assert client.config.index == "my-index"
+    assert client.config.table == "my-table"
+    assert client.config.dimension == 1536
+    assert client.config.region == "us-west-2"
+    assert client.config.filterable_keys == ["topic", "category"]
+    assert client.config.distance_metric == "euclidean"
+    assert client.embedder is mock_oai
+
+
+def test_client_from_env_embedder_resolution(monkeypatch):
+    import dynavec.embeddings.gemini as gemini_mod
+    import dynavec.embeddings.sentence_transformers as st_mod
+    import dynavec.embeddings.voyage as voyage_mod
+
+    monkeypatch.setattr(gemini_mod, "GeminiEmbedder", lambda **kw: MagicMock(dimension=768))
+    monkeypatch.setattr(voyage_mod, "VoyageEmbedder", lambda **kw: MagicMock(dimension=1024))
+    monkeypatch.setattr(st_mod, "SentenceTransformerEmbedder", lambda **kw: MagicMock(dimension=384))
+
+    base_env = {"DYNAVEC_BUCKET": "b", "DYNAVEC_INDEX": "i", "DYNAVEC_TABLE": "t"}
+
+    # Gemini
+    c1 = client_from_env({**base_env, "GEMINI_API_KEY": "gkey"})
+    assert c1.embedder is not None
+    assert c1.config.dimension == 768
+
+    # Voyage
+    c2 = client_from_env({**base_env, "VOYAGE_API_KEY": "vkey"})
+    assert c2.embedder is not None
+    assert c2.config.dimension == 1024
+
+    # Sentence Transformers
+    c3 = client_from_env({**base_env, "DYNAVEC_EMBEDDER": "sentence-transformers"})
+    assert c3.embedder is not None
+    assert c3.config.dimension == 384
+
+    # None
+    c4 = client_from_env({**base_env, "DYNAVEC_EMBEDDER": "none"})
+    assert c4.embedder is None
+    assert c4.config.dimension == 1536
+
+
+def test_mcp_server_search_tool(fake_mcp):
+    mock_db = MagicMock()
+    mock_db.search.return_value = [
+        SearchResult(id="doc-1", score=0.95, text="Hello world", metadata={"topic": "greeting"}),
+        SearchResult(id="doc-2", score=0.82, text="How are you", metadata={}),
+    ]
+
+    mcp = create_mcp_server(mock_db, name="test-dynavec")
+    assert "dynavec_search" in mcp.tools
+    assert "dynavec_graph_search" in mcp.tools
+
+    search_fn = mcp.tools["dynavec_search"].fn
+    result_text = search_fn(
+        query="test query",
+        top_k=2,
+        namespace="custom-ns",
+        filter_json=json.dumps({"topic": "greeting"}),
+        rescore="dot",
+        rerank="mmr",
+    )
+
+    mock_db.search.assert_called_once_with(
+        query="test query",
+        top_k=2,
+        namespace="custom-ns",
+        filter={"topic": "greeting"},
+        rescore="dot",
+        rerank="mmr",
+    )
+    assert "[1] id: doc-1 (score: 0.9500 | metadata: {\"topic\": \"greeting\"})" in result_text
+    assert "Hello world" in result_text
+    assert "[2] id: doc-2 (score: 0.8200)" in result_text
+
+
+def test_mcp_server_search_tool_empty_and_error(fake_mcp):
+    mock_db = MagicMock()
+    mock_db.search.return_value = []
+
+    mcp = create_mcp_server(mock_db)
+    search_fn = mcp.tools["dynavec_search"].fn
+
+    empty_res = search_fn(query="missing", namespace="kb")
+    assert "No results found for query 'missing' in namespace 'kb'." in empty_res
+
+    err_res = search_fn(query="q", filter_json="{invalid json")
+    assert "Error parsing filter_json" in err_res
+
+
+def test_mcp_server_graph_search_tool(fake_mcp):
+    mock_db = MagicMock()
+    mock_db.graph_search.return_value = [
+        SearchResult(id="doc-graph", score=0.91, text="Graph entity content", metadata={"entity": "acme"}),
+    ]
+
+    mcp = create_mcp_server(mock_db)
+    graph_fn = mcp.tools["dynavec_graph_search"].fn
+
+    result_text = graph_fn(
+        query="company news",
+        seed_entities=["acme", "globex"],
+        hops=3,
+        top_k=5,
+        namespace="kb",
+    )
+
+    mock_db.graph_search.assert_called_once_with(
+        query="company news",
+        seed_entities=["acme", "globex"],
+        hops=3,
+        top_k=5,
+        namespace="kb",
+    )
+    assert "Found 1 results for query 'company news'" in result_text
+    assert "id: doc-graph" in result_text
+    assert "Graph entity content" in result_text
+
+
+def test_cli_mcp_subcommand_parser():
+    parser = _parser()
+    args = parser.parse_args(["mcp", "--transport", "sse", "--port", "9000"])
+    assert args.command == "mcp"
+    assert args.transport == "sse"
+    assert args.port == 9000

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -104,14 +104,21 @@ def test_client_from_env_full_configuration(monkeypatch):
 
 def test_client_from_env_embedder_resolution(monkeypatch):
     import dynavec.embeddings.gemini as gemini_mod
+    import dynavec.embeddings.mistral as mistral_mod
     import dynavec.embeddings.sentence_transformers as st_mod
     import dynavec.embeddings.voyage as voyage_mod
 
     monkeypatch.setattr(gemini_mod, "GeminiEmbedder", lambda **kw: MagicMock(dimension=768))
     monkeypatch.setattr(voyage_mod, "VoyageEmbedder", lambda **kw: MagicMock(dimension=1024))
+    monkeypatch.setattr(mistral_mod, "MistralEmbedder", lambda **kw: MagicMock(dimension=1024))
     monkeypatch.setattr(st_mod, "SentenceTransformerEmbedder", lambda **kw: MagicMock(dimension=384))
 
-    base_env = {"DYNAVEC_BUCKET": "b", "DYNAVEC_INDEX": "i", "DYNAVEC_TABLE": "t"}
+    base_env = {
+        "DYNAVEC_BUCKET": "b",
+        "DYNAVEC_INDEX": "i",
+        "DYNAVEC_TABLE": "t",
+        "DYNAVEC_REGION": "us-east-1",
+    }
 
     # Gemini
     c1 = client_from_env({**base_env, "GEMINI_API_KEY": "gkey"})
@@ -123,15 +130,20 @@ def test_client_from_env_embedder_resolution(monkeypatch):
     assert c2.embedder is not None
     assert c2.config.dimension == 1024
 
-    # Sentence Transformers
-    c3 = client_from_env({**base_env, "DYNAVEC_EMBEDDER": "sentence-transformers"})
+    # Mistral
+    c3 = client_from_env({**base_env, "MISTRAL_API_KEY": "mkey"})
     assert c3.embedder is not None
-    assert c3.config.dimension == 384
+    assert c3.config.dimension == 1024
+
+    # Sentence Transformers
+    c4 = client_from_env({**base_env, "DYNAVEC_EMBEDDER": "sentence-transformers"})
+    assert c4.embedder is not None
+    assert c4.config.dimension == 384
 
     # None
-    c4 = client_from_env({**base_env, "DYNAVEC_EMBEDDER": "none"})
-    assert c4.embedder is None
-    assert c4.config.dimension == 1536
+    c5 = client_from_env({**base_env, "DYNAVEC_EMBEDDER": "none"})
+    assert c5.embedder is None
+    assert c5.config.dimension == 1536
 
 
 def test_mcp_server_search_tool(fake_mcp):

--- a/tools/build_docs.py
+++ b/tools/build_docs.py
@@ -632,6 +632,39 @@ index = VectorStoreIndex.from_documents(docs, storage_context=ctx)
 """ + code("""from dynavec.integrations.tools import make_retriever_fn
 retrieve = make_retriever_fn(db, top_k=4)   # fn(query: str) -> str
 # also: as_langchain_tool(db), as_crewai_tool(db)
+""") + """
+<h2>FastMCP server (Claude Desktop, Cursor, AI agents)</h2>
+<p>Expose dynavec as an MCP server with <code>dynavec_search</code> and <code>dynavec_graph_search</code> tools. Configure via environment variables and launch over stdio:</p>
+""" + code("""# Install with MCP extra
+pip install "dynavec[mcp]"
+
+# Launch the FastMCP server via CLI
+dynavec mcp
+""") + """
+<p>Add to your Claude Desktop / Cursor configuration (<code>claude_desktop_config.json</code>):</p>
+""" + code("""{
+  "mcpServers": {
+    "dynavec": {
+      "command": "uvx",
+      "args": ["--with", "dynavec[all]", "dynavec", "mcp"],
+      "env": {
+        "AWS_ACCESS_KEY_ID": "AKIA...",
+        "AWS_SECRET_ACCESS_KEY": "...",
+        "AWS_REGION": "us-east-1",
+        "OPENAI_API_KEY": "sk-...",
+        "DYNAVEC_VECTOR_BUCKET": "my-vectors",
+        "DYNAVEC_INDEX": "docs",
+        "DYNAVEC_TABLE": "dynavec_docs"
+      }
+    }
+  }
+}
+""") + """
+<p>Programmatic initialization is also supported:</p>
+""" + code("""from dynavec.mcp import create_mcp_server
+
+mcp = create_mcp_server(db)
+mcp.run(transport="stdio")
 """))
 
 PAGES["benchmarking"] = ("Benchmarking",


### PR DESCRIPTION
## Summary
Closes #65

Adds a FastMCP server implementation for `dynavec`, enabling AI assistants (Claude Desktop, Cursor, Antigravity, and custom agent runtimes) to perform semantic search and Knowledge Graph RAG over the Model Context Protocol.

## Key Features
- **FastMCP Server (`dynavec.mcp`):** Exposes `dynavec_search` (with filtering, rescoring, reranking) and `dynavec_graph_search` (with seed entities, hops, and vector ranking) tools.
- **Environment-Based Configuration:** `client_from_env()` automatically parses `DYNAVEC_*` and `AWS_*` variables and configures embedders (OpenAI, Gemini, Voyage, Mistral, Bedrock, Sentence Transformers) and credentials.
- **CLI Entry Point:** Added `dynavec mcp [--transport stdio|sse] [--port PORT]`.
- **Lightweight & Isolated:** Lazy imports ensure the core package remains lean (`boto3` + `numpy` only) unless `mcp` extra is used.
- **Unit Tests & Docs:** Added unit tests in `tests/test_mcp_server.py`, example configuration in `examples/mcp_server_config.json`, and updated documentation.

Please let me know if any changes are needed!