### PR TITLE
feat: add PDF ingestion source for #55

### DIFF
--- a/examples/pdf_ingestion.py
+++ b/examples/pdf_ingestion.py
@@ -1,0 +1,37 @@
+"""Ingest a PDF into dynavec (requires AWS credentials + S3 Vectors).
+
+    pip install "dynavec[ingest,sentence-transformers]"
+    python examples/pdf_ingestion.py path/to/document.pdf
+"""
+
+import sys
+
+from dynavec import Dynavec, DynavecConfig
+from dynavec.embeddings import SentenceTransformerEmbedder
+from dynavec.ingest import PDFSource, ingest
+
+if len(sys.argv) != 2:
+    raise SystemExit(
+        "usage: python examples/pdf_ingestion.py path/to/document.pdf"
+    )
+
+# Local embedding model — no external API key required.
+embedder = SentenceTransformerEmbedder(model="all-MiniLM-L6-v2")
+
+cfg = DynavecConfig(
+    vector_bucket="dynavec-demo",
+    index="pdf-ingestion",
+    table="dynavec_pdf_ingestion",
+    dimension=embedder.dimension,
+    distance_metric="cosine",
+    region="us-east-1",
+    auto_provision=True,
+)
+
+db = Dynavec(cfg, embedder=embedder)
+
+source = PDFSource(sys.argv[1])
+
+count = ingest(db, source, namespace="pdf-demo")
+
+print(f"Ingested {count} chunks")

--- a/src/dynavec/ingest.py
+++ b/src/dynavec/ingest.py
@@ -19,9 +19,11 @@ from __future__ import annotations
 import hashlib
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from .client import Dynavec
+from .exceptions import MissingDependencyError
 from .models import Document
 from .utils import chunked
 
@@ -64,6 +66,42 @@ class IterableSource:
     def __iter__(self) -> Iterator[Record]:
         for r in self._records:
             yield r if isinstance(r, Record) else Record(**r)
+
+
+class PDFSource:
+    """Yield one Record per text-bearing page in a PDF."""
+
+    def __init__(self, path: str | Path) -> None:
+        try:
+            from pypdf import PdfReader
+        except ImportError as exc:
+            raise MissingDependencyError(
+                "PDFSource",
+                "pypdf",
+                "ingest",
+            ) from exc
+
+        self._path = Path(path)
+        self._reader_cls = PdfReader
+
+    def __iter__(self) -> Iterator[Record]:
+        reader = self._reader_cls(self._path)
+
+        for page_number, page in enumerate(reader.pages, start=1):
+            text = page.extract_text()
+
+            if not text or not text.strip():
+                continue
+
+            yield Record(
+                id=f"{self._path}#page{page_number}",
+                text=text,
+                metadata={
+                    "source": "pdf",
+                    "path": str(self._path),
+                    "page": page_number,
+                },
+            )
 
 
 class MCPResourceSource:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,6 +1,10 @@
-"""Tests for chunking + the MCP resource source (pure, no AWS)."""
+"""Tests for chunking + MCP/PDF ingestion sources (pure, no AWS)."""
 
-from dynavec.ingest import MCPResourceSource, Record, chunk_text, ingest
+import sys
+from types import SimpleNamespace
+
+from dynavec.exceptions import MissingDependencyError
+from dynavec.ingest import MCPResourceSource, PDFSource, Record, chunk_text, ingest
 from dynavec.models import UpsertResult
 
 
@@ -29,6 +33,54 @@ def test_chunk_text_empty_and_validation():
         list(chunk_text("x", chunk_size=0))
     with pytest.raises(ValueError):
         list(chunk_text("x", chunk_size=4, overlap=4))
+
+
+class _PDFPage:
+    def __init__(self, text):
+        self._text = text
+
+    def extract_text(self):
+        return self._text
+
+
+class _PDFReader:
+    def __init__(self, path):
+        self.path = path
+        self.pages = [
+            _PDFPage("First page text"),
+            _PDFPage("   \n"),
+            _PDFPage("Third page text"),
+        ]
+
+
+def test_pdf_source_yields_page_records(monkeypatch):
+    fake_pypdf = SimpleNamespace(PdfReader=_PDFReader)
+    monkeypatch.setitem(sys.modules, "pypdf", fake_pypdf)
+
+    records = list(PDFSource("docs/sample.pdf"))
+
+    assert len(records) == 2
+
+    assert records[0].id == "docs/sample.pdf#page1"
+    assert records[0].text == "First page text"
+    assert records[0].metadata == {
+        "source": "pdf",
+        "path": "docs/sample.pdf",
+        "page": 1,
+    }
+
+    assert records[1].id == "docs/sample.pdf#page3"
+    assert records[1].text == "Third page text"
+    assert records[1].metadata["page"] == 3
+
+
+def test_pdf_source_missing_dependency(monkeypatch):
+    import pytest
+
+    monkeypatch.setitem(sys.modules, "pypdf", None)
+
+    with pytest.raises(MissingDependencyError, match=r"dynavec\[ingest\]"):
+        PDFSource("sample.pdf")
 
 
 # ---- fake MCP session mirroring the SDK's list_resources / read_resource ----


### PR DESCRIPTION
Closes #55.

Adds PDF ingestion support using `pypdf` and the existing ingestion architecture.

- Adds `PDFSource` with one record per text-bearing page
- Skips blank pages
- Preserves PDF path and page metadata
- Uses the existing `ingest` optional dependency
- Adds tests for page extraction and missing dependency handling
- Adds a PDF ingestion example

Validation:
- Full pytest suite passed
- Ruff passed
- Pre-commit checks passed