### PR TITLE
feat(embeddings): add async embedding support (aembed_documents, aemb…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ all = [
 # --- Dev / test / benchmark ---
 dev = [
     "pytest>=8.0",
+    "pytest-asyncio>=0.23",
     "pytest-cov>=5.0",
     "moto[dynamodb]>=5.0",
     "ruff>=0.6",
@@ -96,6 +97,7 @@ include = ["src/dynavec/py.typed"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"
+asyncio_mode = "auto"
 
 [tool.ruff]
 line-length = 100

--- a/src/dynavec/embeddings/base.py
+++ b/src/dynavec/embeddings/base.py
@@ -8,6 +8,7 @@ sentence-transformers, ...) and supply their *own* API key / credentials.
 
 from __future__ import annotations
 
+import asyncio
 from abc import ABC, abstractmethod
 
 Vector = list[float]
@@ -27,6 +28,44 @@ class Embedder(ABC):
         """Embed a single query. Override if the backend has an asymmetric
         query mode; the default reuses :meth:`embed_documents`."""
         return self.embed_documents([text])[0]
+
+    async def aembed_documents(self, texts: list[str]) -> list[Vector]:
+        """Embed a batch of documents asynchronously.
+
+        The default implementation delegates to synchronous :meth:`embed_documents`
+        inside a worker thread using :func:`asyncio.to_thread`. Subclasses with native
+        asynchronous client support should override this method directly.
+
+        Parameters
+        ----------
+        texts:
+            A list of text strings to embed.
+
+        Returns
+        -------
+        list[Vector]
+            A list of float vector embeddings corresponding to the input texts.
+        """
+        return await asyncio.to_thread(self.embed_documents, texts)
+
+    async def aembed_query(self, text: str) -> Vector:
+        """Embed a single query string asynchronously.
+
+        The default implementation delegates to synchronous :meth:`embed_query`
+        inside a worker thread using :func:`asyncio.to_thread`. Subclasses with native
+        asymmetric or async query support should override this method directly.
+
+        Parameters
+        ----------
+        text:
+            A query string to embed.
+
+        Returns
+        -------
+        Vector
+            A single float vector embedding.
+        """
+        return await asyncio.to_thread(self.embed_query, text)
 
     def __call__(self, texts: list[str]) -> list[Vector]:
         return self.embed_documents(texts)

--- a/tests/test_async_embeddings.py
+++ b/tests/test_async_embeddings.py
@@ -1,0 +1,160 @@
+"""Tests for async embedding support in dynavec.embeddings."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import ClassVar
+
+import pytest
+
+from dynavec.embeddings.base import Embedder, Vector
+
+
+class _SyncTrackingEmbedder(Embedder):
+    """Test embedder that tracks call counts and thread IDs."""
+
+    dimension: ClassVar[int] = 3
+
+    def __init__(self) -> None:
+        self.embed_docs_calls: list[list[str]] = []
+        self.embed_query_calls: list[str] = []
+        self.thread_ids: list[int] = []
+
+    def embed_documents(self, texts: list[str]) -> list[Vector]:
+        self.thread_ids.append(threading.get_ident())
+        self.embed_docs_calls.append(list(texts))
+        return [[float(len(t)), 1.0, 0.0] for t in texts]
+
+    def embed_query(self, text: str) -> Vector:
+        self.thread_ids.append(threading.get_ident())
+        self.embed_query_calls.append(text)
+        return [float(len(text)), 2.0, 0.0]
+
+
+class _NativeAsyncEmbedder(Embedder):
+    """Test embedder providing native async implementation."""
+
+    dimension: ClassVar[int] = 2
+
+    def __init__(self) -> None:
+        self.native_async_docs_called = False
+        self.native_async_query_called = False
+
+    def embed_documents(self, texts: list[str]) -> list[Vector]:
+        raise NotImplementedError("Sync embed_documents should not be called")
+
+    async def aembed_documents(self, texts: list[str]) -> list[Vector]:
+        self.native_async_docs_called = True
+        await asyncio.sleep(0.001)
+        return [[float(len(t)), 99.0] for t in texts]
+
+    async def aembed_query(self, text: str) -> Vector:
+        self.native_async_query_called = True
+        await asyncio.sleep(0.001)
+        return [float(len(text)), 100.0]
+
+
+class _FailingEmbedder(Embedder):
+    """Test embedder that raises an error during embedding."""
+
+    dimension: ClassVar[int] = 2
+
+    def embed_documents(self, texts: list[str]) -> list[Vector]:
+        raise RuntimeError("Embedding service unavailable")
+
+
+@pytest.mark.asyncio
+async def test_aembed_documents_default_thread_offloading():
+    embedder = _SyncTrackingEmbedder()
+    current_thread_id = threading.get_ident()
+
+    vectors = await embedder.aembed_documents(["apple", "banana", "cherry"])
+
+    assert len(vectors) == 3
+    assert vectors[0] == [5.0, 1.0, 0.0]
+    assert vectors[1] == [6.0, 1.0, 0.0]
+    assert vectors[2] == [6.0, 1.0, 0.0]
+    assert embedder.embed_docs_calls == [["apple", "banana", "cherry"]]
+
+    # Execution happened on a worker thread, offloading the event loop
+    assert len(embedder.thread_ids) == 1
+    assert embedder.thread_ids[0] != current_thread_id
+
+
+@pytest.mark.asyncio
+async def test_aembed_query_default_thread_offloading():
+    embedder = _SyncTrackingEmbedder()
+    current_thread_id = threading.get_ident()
+
+    vector = await embedder.aembed_query("search query")
+
+    assert vector == [12.0, 2.0, 0.0]
+    assert embedder.embed_query_calls == ["search query"]
+    assert len(embedder.thread_ids) == 1
+    assert embedder.thread_ids[0] != current_thread_id
+
+
+@pytest.mark.asyncio
+async def test_aembed_documents_empty():
+    embedder = _SyncTrackingEmbedder()
+    vectors = await embedder.aembed_documents([])
+    assert vectors == []
+    assert embedder.embed_docs_calls == [[]]
+
+
+@pytest.mark.asyncio
+async def test_aembed_concurrent_gathering():
+    embedder = _SyncTrackingEmbedder()
+    queries = [f"query_{i}" for i in range(10)]
+
+    results = await asyncio.gather(*(embedder.aembed_query(q) for q in queries))
+
+    assert len(results) == 10
+    for i, res in enumerate(results):
+        expected_len = float(len(f"query_{i}"))
+        assert res == [expected_len, 2.0, 0.0]
+
+
+@pytest.mark.asyncio
+async def test_native_async_override():
+    embedder = _NativeAsyncEmbedder()
+
+    docs = await embedder.aembed_documents(["foo", "barbaz"])
+    assert embedder.native_async_docs_called is True
+    assert docs == [[3.0, 99.0], [6.0, 99.0]]
+
+    query_vec = await embedder.aembed_query("test")
+    assert embedder.native_async_query_called is True
+    assert query_vec == [4.0, 100.0]
+
+
+@pytest.mark.asyncio
+async def test_aembed_exception_propagation():
+    embedder = _FailingEmbedder()
+
+    with pytest.raises(RuntimeError, match="Embedding service unavailable"):
+        await embedder.aembed_documents(["doc"])
+
+    with pytest.raises(RuntimeError, match="Embedding service unavailable"):
+        await embedder.aembed_query("query")
+
+
+@pytest.mark.asyncio
+async def test_aembed_cancellation():
+    class _SlowEmbedder(Embedder):
+        dimension: ClassVar[int] = 1
+
+        def embed_documents(self, texts: list[str]) -> list[Vector]:
+            import time
+
+            time.sleep(0.5)
+            return [[1.0] for _ in texts]
+
+    embedder = _SlowEmbedder()
+    task = asyncio.create_task(embedder.aembed_documents(["slow"]))
+    await asyncio.sleep(0.01)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task


### PR DESCRIPTION
Closes #11

### Summary of Changes
- Added asynchronous embedding protocols `aembed_documents` and `aembed_query` to `dynavec.embeddings.base.Embedder`.
- Implemented default thread offloading using `asyncio.to_thread` so all existing backends (Bedrock, OpenAI, Cohere, Gemini, Mistral, Voyage) inherit async capability out of the box without breaking changes.
- Allowed custom backends to override `aembed_*` methods with native async SDK calls.
- Added full test suite in `tests/test_async_embeddings.py` covering:
  - Worker thread offloading (verifying event loop is never blocked)
  - Single query and batch document async embedding
  - High concurrency using `asyncio.gather`
  - Custom native async subclass override
  - Exception propagation and task cancellation

### Verification
- `pytest -o pythonpath=src tests/test_async_embeddings.py -v` passes (7/7 tests).
- Full regression suite verified against `development`.
- `ruff check` passes cleanly.
