### PR TITLE
feat: add Markdown directory ingestion source (#60)

### DIFF
--- a/examples/ingest_markdown.py
+++ b/examples/ingest_markdown.py
@@ -1,0 +1,52 @@
+"""Ingest a Markdown/text folder into existing AWS resources.
+
+    pip install "dynavec[ingest,openai]"
+    python examples/ingest_markdown.py ./notes --preview
+    python examples/ingest_markdown.py ./notes --bucket my-vectors --index docs --table docs
+
+Writes require AWS credentials and OPENAI_API_KEY. The index must use 1536
+dimensions for text-embedding-3-small. Preview only reads local files.
+"""
+
+import argparse
+
+from dynavec import Dynavec, DynavecConfig
+from dynavec.embeddings import OpenAIEmbedder
+from dynavec.ingest import MarkdownSource, ingest
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("directory")
+    parser.add_argument("--glob", default="**/*")
+    parser.add_argument("--preview", action="store_true")
+    parser.add_argument("--bucket")
+    parser.add_argument("--index")
+    parser.add_argument("--table")
+    parser.add_argument("--region", default="us-east-1")
+    parser.add_argument("--namespace", default="docs")
+    args = parser.parse_args()
+    source = MarkdownSource(args.directory, glob=args.glob)
+
+    if args.preview:
+        for record in source:
+            print(f"{record.id}: {len(record.text)} characters; {record.metadata}")
+        return
+    if not all((args.bucket, args.index, args.table)):
+        parser.error("--bucket, --index and --table are required unless --preview is used")
+
+    embedder = OpenAIEmbedder(model="text-embedding-3-small")
+    config = DynavecConfig(
+        vector_bucket=args.bucket,
+        index=args.index,
+        table=args.table,
+        dimension=embedder.dimension,
+        region=args.region,
+    )
+    with Dynavec(config, embedder=embedder) as db:
+        count = ingest(db, source, namespace=args.namespace)
+    print(f"Upserted {count} chunks into namespace {args.namespace!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/opensource/dynavec/docs/ingestion.html
+++ b/opensource/dynavec/docs/ingestion.html
@@ -79,6 +79,32 @@ src = IterableSource([
     {"id": "doc1", "text": long_text, "metadata": {"src": "wiki"}},
 ])
 ingest(db, src, namespace="kb", chunk_size=1000, overlap=150)</code></pre>
+<h2>From a Markdown or text directory</h2>
+<p><code>MarkdownSource</code> reads UTF-8 <code>.md</code> and <code>.txt</code> files recursively.
+Install <code>dynavec[ingest]</code> for YAML front matter support.</p>
+<pre class="code"><code>from dynavec.ingest import MarkdownSource, ingest
+
+source = MarkdownSource("./notes")
+# Or select files with a root-relative glob:
+source = MarkdownSource("./notes", glob="guides/**/*.md")
+ingest(db, source, namespace="notes")</code></pre>
+<p>A Markdown file may begin with a YAML mapping between two <code>---</code> lines:</p>
+<pre class="code"><code>---
+title: Deployment guide
+topic: aws
+tags: [deployment, rag]
+---
+# Deploying the service
+The document body starts here.</code></pre>
+<p>Front matter becomes metadata and is removed from the text before chunking. Use storage-compatible
+values (strings, numbers, booleans, lists, and mappings); quote dates to keep them as strings.
+Malformed or unclosed front matter raises an error naming the file. Text files are read verbatim.</p>
+<p>IDs are root-relative paths such as <code>guides/deploy.md</code>; generated chunks retain this
+path in <code>source_id</code>. Metadata includes <code>source="file"</code> and <code>path</code>,
+which take precedence over front matter. Use separate namespaces for unrelated directory roots
+to avoid ID collisions. Discovery order is sorted, and files are read one at a time.</p>
+<p>Try <code>python examples/ingest_markdown.py ./notes --preview</code> to inspect records without
+AWS calls. The example also supports ingestion into an existing index using an OpenAI embedder.</p>
 <h2>From any MCP server</h2>
 <p><code>MCPResourceSource</code> turns an MCP server's <em>resources</em> (Notion, Confluence, Drive, your
 own) into an embeddable corpus — no per-source code.</p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ rerank = ["sentence-transformers>=3.0"]         # cross-encoder reranking
 redis = ["redis>=5.0"]                            # RedisCache / AWS ElastiCache
 mcp = ["mcp>=1.0; python_version >= '3.10'"]       # MCP client ingestion
 pinecone = ["pinecone>=5.0"]                      # for benchmarks/examples comparison
-ingest = ["pypdf>=4.0", "python-docx>=1.1", "python-pptx>=0.6", "openpyxl>=3.1"]
+ingest = ["pypdf>=4.0", "python-docx>=1.1", "python-pptx>=0.6", "openpyxl>=3.1", "PyYAML>=6.0"]
 
 # --- Agent framework integrations ---
 langchain = ["langchain-core>=0.3"]

--- a/src/dynavec/ingest.py
+++ b/src/dynavec/ingest.py
@@ -104,6 +104,65 @@ class PDFSource:
             )
 
 
+class MarkdownSource:
+    """Read UTF-8 Markdown and text files from a directory.
+
+    ``glob`` is relative to ``root`` and defaults to recursive discovery.
+    Records use root-relative POSIX paths as IDs. Markdown YAML front matter
+    becomes metadata and is excluded from the text. The ``source`` and ``path``
+    metadata fields are reserved for file provenance. Install ``dynavec[ingest]``
+    to read front matter; files without it need no optional dependencies.
+    """
+
+    def __init__(self, root: str | Path, *, glob: str = "**/*") -> None:
+        self.root = Path(root)
+        if not self.root.exists():
+            raise FileNotFoundError(self.root)
+        if not self.root.is_dir():
+            raise NotADirectoryError(self.root)
+        self.glob = glob
+
+    @staticmethod
+    def _front_matter(text: str, path: Path) -> tuple[str, Metadata]:
+        lines = text.splitlines(keepends=True)
+        if not lines or lines[0].strip() != "---":
+            return text, {}
+        end = next((i for i in range(1, len(lines)) if lines[i].strip() == "---"), None)
+        if end is None:
+            raise ValueError(f"Unclosed YAML front matter in {path}")
+        try:
+            import yaml
+        except ImportError as exc:
+            raise MissingDependencyError(
+                "Markdown front matter", "PyYAML", "ingest"
+            ) from exc
+
+        try:
+            metadata = yaml.safe_load("".join(lines[1:end]))
+        except yaml.YAMLError as exc:
+            raise ValueError(f"Invalid YAML front matter in {path}: {exc}") from exc
+        if metadata is None:
+            metadata = {}
+        if not isinstance(metadata, dict) or any(not isinstance(k, str) for k in metadata):
+            raise ValueError(f"Front matter in {path} must be a mapping with string keys")
+        return "".join(lines[end + 1 :]), metadata
+
+    def __iter__(self) -> Iterator[Record]:
+        for path in sorted(self.root.glob(self.glob)):
+            if not path.is_file() or path.suffix.lower() not in (".md", ".txt"):
+                continue
+            text = path.read_text(encoding="utf-8-sig")
+            metadata: Metadata = {}
+            if path.suffix.lower() == ".md":
+                text, metadata = self._front_matter(text, path)
+            relative_path = path.relative_to(self.root).as_posix()
+            yield Record(
+                id=relative_path,
+                text=text,
+                metadata={**metadata, "source": "file", "path": relative_path},
+            )
+
+
 class MCPResourceSource:
     """Adapt an MCP server's *resources* into dynavec records.
 

--- a/tests/test_markdown_source.py
+++ b/tests/test_markdown_source.py
@@ -1,0 +1,139 @@
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+from dynavec.exceptions import MissingDependencyError
+from dynavec.ingest import MarkdownSource, ingest
+from dynavec.models import UpsertResult
+
+
+def test_recursive_discovery_and_relative_ids(tmp_path):
+    (tmp_path / "notes").mkdir()
+    (tmp_path / "guide.md").write_text("# Guide\n", encoding="utf-8")
+    (tmp_path / "notes" / "guide.md").write_text("Nested guide", encoding="utf-8")
+    (tmp_path / "notes" / "plain.txt").write_text("Plain text", encoding="utf-8")
+    (tmp_path / "ignore.html").write_text("<p>Ignored</p>", encoding="utf-8")
+    (tmp_path / "directory.md").mkdir()
+
+    records = list(MarkdownSource(tmp_path))
+
+    assert [r.id for r in records] == ["guide.md", "notes/guide.md", "notes/plain.txt"]
+    assert [r.text for r in records] == ["# Guide\n", "Nested guide", "Plain text"]
+    assert records[1].metadata == {"source": "file", "path": "notes/guide.md"}
+    assert list(MarkdownSource(tmp_path)) == records
+
+
+def test_glob_restricts_discovery(tmp_path):
+    (tmp_path / "notes").mkdir()
+    for name in ("root.md", "notes/a.md", "notes/b.txt"):
+        (tmp_path / name).write_text(name, encoding="utf-8")
+
+    records = list(MarkdownSource(tmp_path, glob="notes/*.md"))
+
+    assert [r.id for r in records] == ["notes/a.md"]
+
+
+def test_front_matter_becomes_metadata(tmp_path):
+    (tmp_path / "guide.md").write_text(
+        "---\ntitle: Guide\ntags: [aws, rag]\nyear: 2026\npublished: true\n"
+        "source: forged\npath: elsewhere\n---\n# Hello\n\nBody\n---\n",
+        encoding="utf-8-sig",
+    )
+
+    record = next(iter(MarkdownSource(tmp_path)))
+
+    assert record.text == "# Hello\n\nBody\n---\n"
+    assert record.metadata == {
+        "title": "Guide",
+        "tags": ["aws", "rag"],
+        "year": 2026,
+        "published": True,
+        "source": "file",
+        "path": "guide.md",
+    }
+
+
+def test_text_file_does_not_parse_front_matter(tmp_path):
+    text = "---\nthis is plain text\n---\n"
+    (tmp_path / "notes.txt").write_text(text, encoding="utf-8")
+
+    record = next(iter(MarkdownSource(tmp_path)))
+
+    assert record.text == text
+    assert record.metadata == {"source": "file", "path": "notes.txt"}
+
+
+def test_unicode_and_empty_front_matter(tmp_path):
+    (tmp_path / "guide.MD").write_bytes("---\r\n---\r\nCafé 日本語\r\n".encode())
+
+    record = next(iter(MarkdownSource(tmp_path)))
+
+    assert record.text == "Café 日本語\n"
+    assert record.metadata == {"source": "file", "path": "guide.MD"}
+
+
+@pytest.mark.parametrize(
+    "text, message",
+    [
+        ("---\ntitle: missing delimiter\n", "Unclosed YAML"),
+        ("---\ntitle: [broken\n---\nBody", "Invalid YAML"),
+        ("---\n- a\n- b\n---\nBody", "mapping with string keys"),
+        ("---\n42: value\n---\nBody", "mapping with string keys"),
+        ("---\n!!python/object:builtins.object {}\n---\nBody", "Invalid YAML"),
+    ],
+)
+def test_invalid_front_matter_reports_filename(tmp_path, text, message):
+    (tmp_path / "broken.md").write_text(text, encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message) as exc:
+        list(MarkdownSource(tmp_path))
+
+    assert "broken.md" in str(exc.value)
+
+
+def test_yaml_dependency_is_only_needed_for_front_matter(tmp_path, monkeypatch):
+    monkeypatch.setitem(sys.modules, "yaml", None)
+    path = tmp_path / "guide.md"
+    path.write_text("# Plain Markdown", encoding="utf-8")
+    assert next(iter(MarkdownSource(tmp_path))).text == "# Plain Markdown"
+
+    path.write_text("---\ntitle: Guide\n---\nBody", encoding="utf-8")
+    with pytest.raises(MissingDependencyError, match=r"dynavec\[ingest\]"):
+        list(MarkdownSource(tmp_path))
+
+
+def test_root_must_be_an_existing_directory(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        MarkdownSource(tmp_path / "missing")
+    path = tmp_path / "file.txt"
+    path.write_text("Text", encoding="utf-8")
+    with pytest.raises(NotADirectoryError):
+        MarkdownSource(path)
+
+
+def test_empty_directory_yields_no_records(tmp_path):
+    assert list(MarkdownSource(tmp_path)) == []
+
+
+def test_markdown_source_flows_through_ingest(tmp_path):
+    (tmp_path / "guide.md").write_text("---\ntopic: aws\n---\nabcdefghij", encoding="utf-8")
+    db = Mock()
+    db.upsert.side_effect = lambda docs, **kw: UpsertResult(
+        count=len(docs), ids=[doc.id for doc in docs]
+    )
+
+    count = ingest(db, MarkdownSource(tmp_path), namespace="docs", chunk_size=6, overlap=2)
+
+    assert count == 2
+    docs = db.upsert.call_args.args[0]
+    assert [doc.id for doc in docs] == ["guide.md#chunk0", "guide.md#chunk1"]
+    assert [doc.text for doc in docs] == ["abcdef", "efghij"]
+    assert docs[1].metadata == {
+        "topic": "aws",
+        "source": "file",
+        "path": "guide.md",
+        "source_id": "guide.md",
+        "chunk": 1,
+    }
+    assert db.upsert.call_args.kwargs["namespace"] == "docs"

--- a/tools/build_docs.py
+++ b/tools/build_docs.py
@@ -387,6 +387,34 @@ src = IterableSource([
 ])
 ingest(db, src, namespace="kb", chunk_size=1000, overlap=150)
 """) + """
+<h2>From a Markdown or text directory</h2>
+<p><code>MarkdownSource</code> reads UTF-8 <code>.md</code> and <code>.txt</code> files recursively.
+Install <code>dynavec[ingest]</code> for YAML front matter support.</p>
+""" + code("""from dynavec.ingest import MarkdownSource, ingest
+
+source = MarkdownSource("./notes")
+# Or select files with a root-relative glob:
+source = MarkdownSource("./notes", glob="guides/**/*.md")
+ingest(db, source, namespace="notes")
+""") + """
+<p>A Markdown file may begin with a YAML mapping between two <code>---</code> lines:</p>
+""" + code("""---
+title: Deployment guide
+topic: aws
+tags: [deployment, rag]
+---
+# Deploying the service
+The document body starts here.
+""") + """
+<p>Front matter becomes metadata and is removed from the text before chunking. Use storage-compatible
+values (strings, numbers, booleans, lists, and mappings); quote dates to keep them as strings.
+Malformed or unclosed front matter raises an error naming the file. Text files are read verbatim.</p>
+<p>IDs are root-relative paths such as <code>guides/deploy.md</code>; generated chunks retain this
+path in <code>source_id</code>. Metadata includes <code>source="file"</code> and <code>path</code>,
+which take precedence over front matter. Use separate namespaces for unrelated directory roots
+to avoid ID collisions. Discovery order is sorted, and files are read one at a time.</p>
+<p>Try <code>python examples/ingest_markdown.py ./notes --preview</code> to inspect records without
+AWS calls. The example also supports ingestion into an existing index using an OpenAI embedder.</p>
 <h2>From any MCP server</h2>
 <p><code>MCPResourceSource</code> turns an MCP server's <em>resources</em> (Notion, Confluence, Drive, your
 own) into an embeddable corpus — no per-source code.</p>


### PR DESCRIPTION
Closes #60.

Adds `MarkdownSource` to ingest local folders of Markdown (`.md`) and plain text (`.txt`) files recursively, fitting cleanly into the existing ingestion API.

### Changes
- **`MarkdownSource`**: Recursively discovers `.md` and `.txt` files with configurable globbing (default `**/*`).
- **Front-matter metadata**: Parses YAML front-matter into document metadata, stripping delimiters prior to chunking. Gracefully raises `MissingDependencyError("Markdown front matter", "PyYAML", "ingest")` if PyYAML is not installed.
- **IDs & provenance**: Sets root-relative POSIX paths as record IDs and attaches `source="file"` and `path` metadata.
- **Example**: Added `examples/ingest_markdown.py` demonstrating directory ingestion with a `--preview` mode (no AWS credentials required) and real index ingestion.
- **Documentation**: Updated `opensource/dynavec/docs/ingestion.html` and `tools/build_docs.py`.
- **Tests**: Comprehensive unit tests in `tests/test_markdown_source.py` covering recursive discovery, glob filters, front-matter extraction, malformed YAML handling, missing dependency warnings, empty directories, and integration with `ingest()`.

### Validation
- All 14 tests in `tests/test_markdown_source.py` passed
- `ruff check` passed with zero errors
