### PR TITLE
feat(concurrency): add max_pool_connections tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ hit-rate, and a filterable **traces** table with per-trace drill-down.
 | Area | What you get | API |
 |------|--------------|-----|
 | **Distance metrics** | Index on cosine/euclidean (S3 Vectors native); client-side rescore in cosine / dot / euclidean / manhattan or a **weighted combination**, with optional result-set normalization | `search(..., rescore="dot", normalize_scores=True)` |
-| **Concurrency** | GIL-aware thread pool — real parallelism for I/O-bound AWS calls; parallel batched writes + `search_many` | `DynavecConfig(max_workers=8)`, `db.search_many([...])` |
+| **Concurrency** | GIL-aware thread pool — real parallelism for I/O-bound AWS calls; parallel batched writes + `search_many`; tunable botocore connection pool | `DynavecConfig(max_workers=8, max_pool_connections=50)`, `db.search_many([...])` |
 | **Streaming** | Results yielded page-by-page as S3 Vectors paginates, so agents start consuming early | `for hit in db.search_stream(q): ...` |
 | **Namespace RAG** | Per-tenant/collection handles; isolation + even partitioning | `kb = db.namespace("kb"); kb.search(...)` |
 | **Product quantization** | Compress cached/hot-tier vectors up to 32× (ADC distance) | `ProductQuantizer(m=96).fit(X)` |

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ hit-rate, and a filterable **traces** table with per-trace drill-down.
 | Area | What you get | API |
 |------|--------------|-----|
 | **Distance metrics** | Index on cosine/euclidean (S3 Vectors native); client-side rescore in cosine / dot / euclidean / manhattan or a **weighted combination**, with optional result-set normalization | `search(..., rescore="dot", normalize_scores=True)` |
-| **Concurrency** | GIL-aware thread pool — real parallelism for I/O-bound AWS calls; parallel batched writes + `search_many`; tunable botocore connection pool | `DynavecConfig(max_workers=8, max_pool_connections=50)`, `db.search_many([...])` |
+| **Concurrency** | GIL-aware thread pool — real parallelism for I/O-bound AWS calls; parallel batched writes + `search_many`; tunable botocore connection pool (default 10, raise for high concurrency) | `DynavecConfig(max_workers=8, max_pool_connections=50)`, `db.search_many([...])` |
 | **Streaming** | Results yielded page-by-page as S3 Vectors paginates, so agents start consuming early | `for hit in db.search_stream(q): ...` |
 | **Namespace RAG** | Per-tenant/collection handles; isolation + even partitioning | `kb = db.namespace("kb"); kb.search(...)` |
 | **Product quantization** | Compress cached/hot-tier vectors up to 32× (ADC distance) | `ProductQuantizer(m=96).fit(X)` |

--- a/src/dynavec/cache.py
+++ b/src/dynavec/cache.py
@@ -200,7 +200,11 @@ class DynamoDBCache(BaseCache):
         import boto3
 
         session = boto_session or boto3.Session()
-        self._table = session.resource("dynamodb", region_name=config.region).Table(config.table)
+        resource_kwargs: dict[str, object] = {"region_name": config.region}
+        botocore_config = config.botocore_config()
+        if botocore_config is not None:
+            resource_kwargs["config"] = botocore_config
+        self._table = session.resource("dynamodb", **resource_kwargs).Table(config.table)  # type: ignore[arg-type]
         self.ttl_seconds = ttl_seconds
 
     @staticmethod

--- a/src/dynavec/config.py
+++ b/src/dynavec/config.py
@@ -52,6 +52,9 @@ class DynavecConfig:
         Optional client-side chunk size for streamed query pages. ``None``
         (default) yields native Amazon S3 Vectors pages (at most 100 vectors).
         Does not change the service page size.
+    max_pool_connections:
+        Optional botocore ``max_pool_connections`` tuning for DynamoDB and
+        S3 Vectors clients. ``None`` (default) keeps boto3/botocore defaults.
     """
 
     vector_bucket: str
@@ -75,10 +78,23 @@ class DynavecConfig:
     # the GIL during network calls). See client._executor.
     max_workers: int = 8
     parallel_writes: bool = True
+    max_pool_connections: int | None = None
 
     # provisioning
     auto_provision: bool = False
     dynamodb_billing_mode: Literal["PAY_PER_REQUEST", "PROVISIONED"] = "PAY_PER_REQUEST"
+
+    def botocore_config(self):  # type: ignore[no-untyped-def]
+        """Return a botocore Config with pool tuning, or None for defaults.
+
+        Local import keeps the base package cheap (boto3/botocore stay
+        optional until a store actually builds a client).
+        """
+        if self.max_pool_connections is None:
+            return None
+        from botocore.config import Config
+
+        return Config(max_pool_connections=self.max_pool_connections)
 
     def __post_init__(self) -> None:
         if self.dimension <= 0:
@@ -89,3 +105,5 @@ class DynavecConfig:
             raise ValueError("over_fetch must be >= 1")
         if self.top_k_page_size is not None and self.top_k_page_size <= 0:
             raise ValueError("top_k_page_size must be a positive integer")
+        if self.max_pool_connections is not None and self.max_pool_connections <= 0:
+            raise ValueError("max_pool_connections must be a positive integer")

--- a/src/dynavec/config.py
+++ b/src/dynavec/config.py
@@ -54,7 +54,8 @@ class DynavecConfig:
         Does not change the service page size.
     max_pool_connections:
         Optional botocore ``max_pool_connections`` tuning for DynamoDB and
-        S3 Vectors clients. ``None`` (default) keeps boto3/botocore defaults.
+        S3 Vectors clients. ``None`` (default) keeps boto3/botocore defaults
+        (currently 10 connections per client).
     """
 
     vector_bucket: str

--- a/src/dynavec/graph.py
+++ b/src/dynavec/graph.py
@@ -39,7 +39,11 @@ class GraphStore:
 
         session = boto_session or boto3.Session()
         self._config = config
-        self._ddb = session.resource("dynamodb", region_name=config.region)
+        resource_kwargs: dict[str, object] = {"region_name": config.region}
+        botocore_config = config.botocore_config()
+        if botocore_config is not None:
+            resource_kwargs["config"] = botocore_config
+        self._ddb = session.resource("dynamodb", **resource_kwargs)  # type: ignore[arg-type]
         self._table = self._ddb.Table(config.table)
 
     @staticmethod

--- a/src/dynavec/provisioning.py
+++ b/src/dynavec/provisioning.py
@@ -22,7 +22,11 @@ def ensure_vector_bucket(config: DynavecConfig, boto_session=None) -> None:
     import boto3
 
     session = boto_session or boto3.Session()
-    s3v = session.client("s3vectors", region_name=config.region)
+    client_kwargs: dict[str, object] = {"region_name": config.region}
+    botocore_config = config.botocore_config()
+    if botocore_config is not None:
+        client_kwargs["config"] = botocore_config
+    s3v = session.client("s3vectors", **client_kwargs)  # type: ignore[arg-type]
     try:
         s3v.create_vector_bucket(vectorBucketName=config.vector_bucket)
     except Exception as exc:  # noqa: BLE001
@@ -35,7 +39,11 @@ def ensure_index(config: DynavecConfig, boto_session=None) -> None:
     import boto3
 
     session = boto_session or boto3.Session()
-    s3v = session.client("s3vectors", region_name=config.region)
+    client_kwargs: dict[str, object] = {"region_name": config.region}
+    botocore_config = config.botocore_config()
+    if botocore_config is not None:
+        client_kwargs["config"] = botocore_config
+    s3v = session.client("s3vectors", **client_kwargs)  # type: ignore[arg-type]
 
     non_filterable = list(config.non_filterable_keys)
     if config.store_text_in_s3vectors and TEXT_METADATA_KEY not in non_filterable:
@@ -63,7 +71,11 @@ def ensure_table(config: DynavecConfig, boto_session=None) -> None:
     import boto3
 
     session = boto_session or boto3.Session()
-    ddb = session.client("dynamodb", region_name=config.region)
+    client_kwargs: dict[str, object] = {"region_name": config.region}
+    botocore_config = config.botocore_config()
+    if botocore_config is not None:
+        client_kwargs["config"] = botocore_config
+    ddb = session.client("dynamodb", **client_kwargs)  # type: ignore[arg-type]
 
     try:
         create_kwargs = {

--- a/src/dynavec/stores/dynamodb.py
+++ b/src/dynavec/stores/dynamodb.py
@@ -54,7 +54,11 @@ class DynamoDBStore:
 
         session = boto_session or boto3.Session()
         self._config = config
-        self._ddb = session.resource("dynamodb", region_name=config.region)
+        resource_kwargs: dict[str, object] = {"region_name": config.region}
+        botocore_config = config.botocore_config()
+        if botocore_config is not None:
+            resource_kwargs["config"] = botocore_config
+        self._ddb = session.resource("dynamodb", **resource_kwargs)  # type: ignore[arg-type]
         self._table = self._ddb.Table(config.table)
 
     @staticmethod

--- a/src/dynavec/stores/s3vectors.py
+++ b/src/dynavec/stores/s3vectors.py
@@ -39,7 +39,11 @@ class S3VectorsStore:
 
         session = boto_session or boto3.Session()
         self._config = config
-        self._client = session.client("s3vectors", region_name=config.region)
+        client_kwargs: dict[str, object] = {"region_name": config.region}
+        botocore_config = config.botocore_config()
+        if botocore_config is not None:
+            client_kwargs["config"] = botocore_config
+        self._client = session.client("s3vectors", **client_kwargs)  # type: ignore[arg-type]
 
     @retry()
     def _put_batch(self, payload: list[dict]) -> None:

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -1,0 +1,99 @@
+"""Tests for DynavecConfig.max_pool_connections plumbing (issue #54)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from dynavec.cache import DynamoDBCache
+from dynavec.config import DynavecConfig
+from dynavec.graph import GraphStore
+from dynavec.provisioning import ensure_index, ensure_table, ensure_vector_bucket
+from dynavec.stores.dynamodb import DynamoDBStore
+from dynavec.stores.s3vectors import S3VectorsStore
+
+
+def _config(**kwargs):
+    defaults = dict(vector_bucket="b", index="i", table="t", dimension=4)
+    defaults.update(kwargs)
+    return DynavecConfig(**defaults)
+
+
+def test_max_pool_connections_defaults_to_none():
+    assert _config().max_pool_connections is None
+    assert _config().botocore_config() is None
+
+
+def test_max_pool_connections_validation():
+    with pytest.raises(ValueError):
+        _config(max_pool_connections=0)
+    with pytest.raises(ValueError):
+        _config(max_pool_connections=-5)
+
+
+def test_botocore_config_carries_pool_size():
+    cfg = _config(max_pool_connections=50)
+    client_config = cfg.botocore_config()
+    assert client_config is not None
+    assert client_config.max_pool_connections == 50
+
+
+def _mock_session():
+    session = MagicMock()
+    resource = MagicMock()
+    resource.Table.return_value = MagicMock()
+    session.resource.return_value = resource
+    session.client.return_value = MagicMock()
+    return session
+
+
+def test_dynamodb_store_passes_config():
+    session = _mock_session()
+    DynamoDBStore(_config(max_pool_connections=25), boto_session=session)
+    _, kwargs = session.resource.call_args
+    assert kwargs["config"].max_pool_connections == 25
+
+
+def test_dynamodb_store_omits_config_by_default():
+    session = _mock_session()
+    DynamoDBStore(_config(), boto_session=session)
+    _, kwargs = session.resource.call_args
+    assert "config" not in kwargs
+
+
+def test_s3vectors_store_passes_config():
+    session = _mock_session()
+    S3VectorsStore(_config(max_pool_connections=25), boto_session=session)
+    _, kwargs = session.client.call_args
+    assert kwargs["config"].max_pool_connections == 25
+
+
+def test_s3vectors_store_omits_config_by_default():
+    session = _mock_session()
+    S3VectorsStore(_config(), boto_session=session)
+    _, kwargs = session.client.call_args
+    assert "config" not in kwargs
+
+
+def test_graph_store_passes_config():
+    session = _mock_session()
+    GraphStore(_config(max_pool_connections=12), boto_session=session)
+    _, kwargs = session.resource.call_args
+    assert kwargs["config"].max_pool_connections == 12
+
+
+def test_dynamodb_cache_passes_config():
+    session = _mock_session()
+    DynamoDBCache(_config(max_pool_connections=12), boto_session=session)
+    _, kwargs = session.resource.call_args
+    assert kwargs["config"].max_pool_connections == 12
+
+
+def test_provisioning_passes_config():
+    session = _mock_session()
+    cfg = _config(max_pool_connections=30)
+    ensure_vector_bucket(cfg, boto_session=session)
+    ensure_index(cfg, boto_session=session)
+    ensure_table(cfg, boto_session=session)
+    for call in session.client.call_args_list:
+        _, kwargs = call
+        assert kwargs["config"].max_pool_connections == 30


### PR DESCRIPTION
## Summary

Closes #54

Adds optional `DynavecConfig.max_pool_connections` tuning, plumbed via botocore `Config` to DynamoDB, S3 Vectors, graph, cache, and provisioning clients. Defaults to `None` (boto defaults), preserving backwards compatibility.

## Verification

- `ruff check src benchmarks tests` passes cleanly.
- `pytest tests/test_connection_pool.py -v`: 10 passed (validation + Config plumbing for all stores, cache, and provisioning).
- Full `pytest`: 224 passed, 2 skipped (1 pre-existing Windows-only failure in `test_ingest.py::test_pdf_source_yields_page_records`, also fails on clean `development` due to path separator).
