### PR TITLE
feat(eval): pluggable LLM judge for RAG faithfulness and answer relevance (#135)

### DIFF
--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -34,6 +34,8 @@ export interface TraceEvent {
   status: string;
   error: string | null;
   query_preview: string | null;
+  eval_faithfulness?: number | null;
+  eval_relevance?: number | null;
 }
 
 export interface TraceFilters {

--- a/src/dynavec/dashboard.py
+++ b/src/dynavec/dashboard.py
@@ -25,7 +25,7 @@ import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import parse_qs, urlparse
 
-from .telemetry import TelemetryRecorder, aggregate
+from .telemetry import TelemetryRecorder, aggregate, aggregate_eval
 
 _INDEX_HTML = r"""<!doctype html>
 <html lang="en"><head>
@@ -242,6 +242,18 @@ def _make_handler(recorder: TelemetryRecorder):
                 if ev is None:
                     return self._send(404, json.dumps({"error": "not found"}))
                 return self._send(200, json.dumps(ev.to_dict()))
+            if path == "/api/eval/summary":
+                window = int(qs.get("window", ["86400"])[0])
+                return self._send(200, json.dumps(aggregate_eval(recorder.snapshot(), window)))
+            if path == "/api/eval/runs":
+                limit = int(qs.get("limit", ["50"])[0])
+                all_events = recorder.events(limit=recorder._events.maxlen or 10000)
+                eval_runs = [
+                    e.to_dict()
+                    for e in all_events
+                    if e.eval_faithfulness is not None or e.eval_relevance is not None
+                ][:limit]
+                return self._send(200, json.dumps(eval_runs))
             return self._send(404, json.dumps({"error": "not found"}))
 
     return Handler

--- a/src/dynavec/eval/__init__.py
+++ b/src/dynavec/eval/__init__.py
@@ -1,0 +1,49 @@
+"""LLM-as-a-Judge evaluation framework for RAG faithfulness and answer relevance."""
+
+from __future__ import annotations
+
+from .base import (
+    AnswerRelevanceResult,
+    BaseJudge,
+    ClaimVerification,
+    FaithfulnessResult,
+    RAGEvalResult,
+    extract_json,
+)
+from .chart import plot_eval_summary
+from .judges import (
+    BedrockJudge,
+    CustomJudge,
+    GeminiJudge,
+    MockJudge,
+    OpenAIJudge,
+)
+from .metrics import (
+    evaluate_answer_relevance,
+    evaluate_faithfulness,
+    evaluate_rag,
+)
+from .runner import (
+    EvalRunner,
+    EvalSummary,
+)
+
+__all__ = [
+    "BaseJudge",
+    "OpenAIJudge",
+    "BedrockJudge",
+    "GeminiJudge",
+    "CustomJudge",
+    "MockJudge",
+    "ClaimVerification",
+    "FaithfulnessResult",
+    "AnswerRelevanceResult",
+    "RAGEvalResult",
+    "extract_json",
+    "evaluate_faithfulness",
+    "evaluate_answer_relevance",
+    "evaluate_rag",
+    "EvalRunner",
+    "EvalSummary",
+    "plot_eval_summary",
+]

--- a/src/dynavec/eval/base.py
+++ b/src/dynavec/eval/base.py
@@ -1,0 +1,119 @@
+"""Base abstractions and data models for LLM-as-a-Judge evaluation."""
+
+from __future__ import annotations
+
+import json
+import re
+from abc import ABC, abstractmethod
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+def extract_json(text: str) -> dict[str, Any]:
+    """Extract and parse a JSON object from raw LLM output.
+
+    Handles:
+    - Raw JSON string: '{"score": 1.0}'
+    - Markdown fenced code blocks: '```json\n{"score": 1.0}\n```'
+    - Text with embedded JSON: 'Evaluation result: {"score": 1.0} Explanation: ...'
+    """
+    clean = text.strip()
+    if not clean:
+        raise ValueError("Empty response from LLM judge.")
+
+    # 1. Try direct json parsing
+    try:
+        data = json.loads(clean)
+        if isinstance(data, dict):
+            return data
+    except json.JSONDecodeError:
+        pass
+
+    # 2. Try markdown fenced code block (```json ... ``` or ``` ... ```)
+    fenced_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", clean, re.DOTALL)
+    if fenced_match:
+        try:
+            return json.loads(fenced_match.group(1))
+        except json.JSONDecodeError:
+            pass
+
+    # 3. Try finding outermost matching braces { ... }
+    first_brace = clean.find("{")
+    last_brace = clean.rfind("}")
+    if first_brace != -1 and last_brace != -1 and last_brace > first_brace:
+        candidate = clean[first_brace : last_brace + 1]
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            pass
+
+    raise ValueError(f"Could not parse valid JSON object from LLM judge response:\n{clean}")
+
+
+@dataclass
+class ClaimVerification:
+    """Verification result for a single atomic claim."""
+
+    claim: str
+    supported: bool
+    reasoning: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class FaithfulnessResult:
+    """Result of a faithfulness / groundedness evaluation."""
+
+    score: float
+    claims: list[ClaimVerification] = field(default_factory=list)
+    reasoning: str = ""
+    supported_count: int = 0
+    total_count: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class AnswerRelevanceResult:
+    """Result of an answer relevance evaluation."""
+
+    score: float
+    reasoning: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class RAGEvalResult:
+    """Combined RAG evaluation result for a query, context, and answer."""
+
+    query: str
+    context: list[str]
+    answer: str
+    faithfulness: FaithfulnessResult | None = None
+    answer_relevance: AnswerRelevanceResult | None = None
+    latency_ms: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class BaseJudge(ABC):
+    """Abstract base class for LLM judges.
+
+    Subclasses must implement :meth:`judge` to generate raw text responses from
+    the target LLM model.
+    """
+
+    @abstractmethod
+    def judge(self, prompt: str) -> str:
+        """Send a prompt to the LLM judge and return its raw response string."""
+
+    def judge_structured(self, prompt: str) -> dict[str, Any]:
+        """Send a prompt and extract a structured JSON dictionary from the response."""
+        raw_text = self.judge(prompt)
+        return extract_json(raw_text)

--- a/src/dynavec/eval/chart.py
+++ b/src/dynavec/eval/chart.py
@@ -1,0 +1,111 @@
+"""Visual charting for RAG evaluation scores (Faithfulness vs Answer Relevance)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .runner import EvalSummary
+
+
+def plot_eval_summary(
+    summary: EvalSummary,
+    output_path: str = "eval_scores.png",
+    title: str = "RAG Evaluation: Faithfulness vs Answer Relevance",
+) -> str:
+    """Generate a scatter and distribution chart for batch evaluation results.
+
+    Parameters
+    ----------
+    summary:
+        EvalSummary object containing results from EvalRunner.
+    output_path:
+        File path to save the generated PNG chart.
+    title:
+        Chart title.
+
+    Returns
+    -------
+    str:
+        The output path where the chart was saved.
+    """
+    try:
+        import matplotlib
+        matplotlib.use("Agg")  # headless mode
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        from ..exceptions import MissingDependencyError
+        raise MissingDependencyError("plot_eval_summary", "matplotlib", "benchmark") from exc
+
+    results = summary.results
+    if not results:
+        raise ValueError("Cannot plot empty evaluation results.")
+
+    faith_scores = [
+        r.faithfulness.score if r.faithfulness is not None else 0.0
+        for r in results
+    ]
+    rel_scores = [
+        r.answer_relevance.score if r.answer_relevance is not None else 0.0
+        for r in results
+    ]
+
+    fig, ax = plt.subplots(figsize=(8, 6), dpi=150)
+    fig.patch.set_facecolor("#FBFAF8")
+    ax.set_facecolor("#FFFFFF")
+
+    # Scatter plot
+    ax.scatter(
+        faith_scores,
+        rel_scores,
+        c="#E8623B",
+        alpha=0.75,
+        s=60,
+        edgecolors="#B8472A",
+        linewidth=1.2,
+        label="Evaluated Queries",
+        zorder=3,
+    )
+
+    # Reference lines for pass threshold
+    threshold = summary.pass_threshold
+    ax.axvline(threshold, color="#6F6862", linestyle="--", alpha=0.5, label=f"Pass Threshold ({threshold})")
+    ax.axhline(threshold, color="#6F6862", linestyle="--", alpha=0.5)
+
+    # Mean score crosshairs
+    ax.scatter(
+        [summary.mean_faithfulness],
+        [summary.mean_relevance],
+        c="#2F7D5B",
+        s=140,
+        marker="X",
+        label=f"Mean (F:{summary.mean_faithfulness:.2f}, R:{summary.mean_relevance:.2f})",
+        zorder=4,
+    )
+
+    ax.set_xlim(-0.05, 1.05)
+    ax.set_ylim(-0.05, 1.05)
+    ax.set_xlabel("Faithfulness (Groundedness in Context)", fontsize=11, fontweight="bold", color="#14110F")
+    ax.set_ylabel("Answer Relevance (Intent Alignment)", fontsize=11, fontweight="bold", color="#14110F")
+    ax.set_title(title, fontsize=13, fontweight="bold", pad=12, color="#14110F")
+
+    # Styling
+    ax.grid(True, linestyle=":", alpha=0.6, color="#ECE6DF")
+    for spine in ax.spines.values():
+        spine.set_color("#ECE6DF")
+
+    ax.legend(loc="lower left", framealpha=0.9, facecolor="#FBFAF8", edgecolor="#ECE6DF")
+
+    # Add subtitle annotations
+    stats_text = (
+        f"Total Samples: {summary.total_samples}  |  "
+        f"Pass Rate: {summary.pass_rate * 100:.1f}%  |  "
+        f"p95 Latency: {summary.p95_latency_ms:.1f}ms"
+    )
+    plt.figtext(0.5, 0.02, stats_text, ha="center", fontsize=9, color="#6F6862", family="monospace")
+
+    plt.tight_layout(rect=(0, 0.04, 1, 1))
+    plt.savefig(output_path, bbox_inches="tight")
+    plt.close(fig)
+
+    return output_path

--- a/src/dynavec/eval/judges.py
+++ b/src/dynavec/eval/judges.py
@@ -1,0 +1,206 @@
+"""Pluggable LLM judge implementations (OpenAI, Bedrock, Gemini, Custom, Mock)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from ..credentials import resolve_session
+from ..exceptions import MissingDependencyError
+from .base import BaseJudge
+
+
+class OpenAIJudge(BaseJudge):
+    """LLM judge using OpenAI's chat completions API (bring your own API key).
+
+    Parameters
+    ----------
+    model:
+        Model name, e.g. ``"gpt-4o-mini"`` or ``"gpt-4o"``.
+    api_key:
+        Optional; falls back to the ``OPENAI_API_KEY`` environment variable.
+    base_url:
+        Optional custom endpoint URL (e.g. for Ollama / vLLM / Azure).
+    temperature:
+        Sampling temperature (default 0.0 for deterministic evaluation).
+    """
+
+    def __init__(
+        self,
+        model: str = "gpt-4o-mini",
+        api_key: str | None = None,
+        base_url: str | None = None,
+        temperature: float = 0.0,
+    ) -> None:
+        try:
+            from openai import OpenAI
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise MissingDependencyError("OpenAIJudge", "openai", "openai") from exc
+
+        self.model = model
+        self.temperature = temperature
+        self._client = OpenAI(api_key=api_key, base_url=base_url)
+
+    def judge(self, prompt: str) -> str:
+        resp = self._client.chat.completions.create(
+            model=self.model,
+            temperature=self.temperature,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return resp.choices[0].message.content or ""
+
+
+class BedrockJudge(BaseJudge):
+    """LLM judge using Amazon Bedrock foundation models (Claude 3, Titan, etc.).
+
+    Parameters
+    ----------
+    model_id:
+        Bedrock model ID, e.g. ``"anthropic.claude-3-haiku-20240307-v1:0"`` or
+        ``"amazon.titan-text-express-v1"``.
+    region:
+        AWS region for the Bedrock endpoint.
+    temperature:
+        Sampling temperature (default 0.0).
+    boto_session:
+        Optional custom boto3 Session.
+    """
+
+    def __init__(
+        self,
+        model_id: str = "anthropic.claude-3-haiku-20240307-v1:0",
+        region: str | None = None,
+        temperature: float = 0.0,
+        boto_session=None,
+    ) -> None:
+        session = resolve_session(None, boto_session)
+        kwargs: dict[str, Any] = {}
+        if region:
+            kwargs["region_name"] = region
+        self._client = session.client("bedrock-runtime", **kwargs)
+        self.model_id = model_id
+        self.temperature = temperature
+
+    def judge(self, prompt: str) -> str:
+        if "anthropic.claude" in self.model_id:
+            payload = {
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": 2048,
+                "temperature": self.temperature,
+                "messages": [{"role": "user", "content": prompt}],
+            }
+            resp = self._client.invoke_model(
+                modelId=self.model_id,
+                contentType="application/json",
+                accept="application/json",
+                body=json.dumps(payload),
+            )
+            data = json.loads(resp["body"].read())
+            contents = data.get("content", [])
+            return contents[0].get("text", "") if contents else ""
+
+        # Default / Titan payload format
+        payload = {
+            "inputText": prompt,
+            "textGenerationConfig": {
+                "maxTokenCount": 2048,
+                "temperature": self.temperature,
+            },
+        }
+        resp = self._client.invoke_model(
+            modelId=self.model_id,
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(payload),
+        )
+        data = json.loads(resp["body"].read())
+        results = data.get("results", [])
+        return results[0].get("outputText", "") if results else ""
+
+
+class GeminiJudge(BaseJudge):
+    """LLM judge using Google Gemini models (bring your own API key).
+
+    Parameters
+    ----------
+    model:
+        Model name, e.g. ``"gemini-1.5-flash"`` or ``"gemini-1.5-pro"``.
+    api_key:
+        Optional; falls back to ``GEMINI_API_KEY`` or ``GOOGLE_API_KEY``.
+    temperature:
+        Sampling temperature (default 0.0).
+    """
+
+    def __init__(
+        self,
+        model: str = "gemini-1.5-flash",
+        api_key: str | None = None,
+        temperature: float = 0.0,
+    ) -> None:
+        try:
+            import google.generativeai as genai
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise MissingDependencyError("GeminiJudge", "google-generativeai", "gemini") from exc
+
+        if api_key:
+            genai.configure(api_key=api_key)
+        self._model = genai.GenerativeModel(
+            model_name=model,
+            generation_config={"temperature": temperature},
+        )
+
+    def judge(self, prompt: str) -> str:
+        resp = self._model.generate_content(prompt)
+        return resp.text or ""
+
+
+class CustomJudge(BaseJudge):
+    """LLM judge wrapping any custom Python callable or function.
+
+    Parameters
+    ----------
+    fn:
+        Callable taking a string prompt and returning a string response.
+    """
+
+    def __init__(self, fn: Callable[[str], str]) -> None:
+        if not callable(fn):
+            raise TypeError("fn must be a callable taking a prompt string.")
+        self._fn = fn
+
+    def judge(self, prompt: str) -> str:
+        return self._fn(prompt)
+
+
+class MockJudge(BaseJudge):
+    """Deterministic mock judge for unit testing and offline benchmarking.
+
+    Parameters
+    ----------
+    responses:
+        Optional list of sequential responses to return on consecutive calls.
+    default_response:
+        Default fallback response when responses list is empty or exhausted.
+    """
+
+    def __init__(
+        self,
+        responses: list[str | dict[str, Any]] | None = None,
+        default_response: str | dict[str, Any] | None = None,
+    ) -> None:
+        self._responses: list[str] = [
+            json.dumps(r) if isinstance(r, dict) else str(r) for r in (responses or [])
+        ]
+        self._default: str = (
+            json.dumps(default_response)
+            if isinstance(default_response, dict)
+            else str(default_response or '{"score": 1.0, "reasoning": "Mock evaluation"}')
+        )
+        self.call_history: list[str] = []
+
+    def judge(self, prompt: str) -> str:
+        self.call_history.append(prompt)
+        if self._responses:
+            return self._responses.pop(0)
+        return self._default

--- a/src/dynavec/eval/metrics.py
+++ b/src/dynavec/eval/metrics.py
@@ -1,0 +1,271 @@
+"""Core RAG evaluation metrics: Faithfulness (hallucination detection) and Answer Relevance."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+
+from .base import (
+    AnswerRelevanceResult,
+    BaseJudge,
+    ClaimVerification,
+    FaithfulnessResult,
+    RAGEvalResult,
+)
+
+_FAITHFULNESS_PROMPT_TEMPLATE = """You are an expert evaluator assessing the FAITHFULNESS (groundedness) of a generated answer with respect to retrieved context.
+
+Task:
+1. Break down the generated answer into discrete, atomic factual statements/claims.
+2. For each claim, determine whether it is directly ENTAILED and SUPPORTED by the provided context.
+   - "supported": true if the context directly confirms or logically entails the claim.
+   - "supported": false if the context contradicts, fails to mention, or only partially supports the claim.
+3. Provide a brief reasoning for each claim.
+
+Retrieved Context:
+{context_text}
+
+User Query:
+{query}
+
+Generated Answer:
+{answer}
+
+Respond ONLY with a JSON object in this exact schema:
+{{
+  "claims": [
+    {{
+      "claim": "<statement extracted from answer>",
+      "supported": true,
+      "reasoning": "<why this claim is or is not supported by the context>"
+    }}
+  ],
+  "reasoning": "<overall summary of faithfulness>"
+}}
+"""
+
+_RELEVANCE_PROMPT_TEMPLATE = """You are an expert evaluator assessing the ANSWER RELEVANCE of a generated answer with respect to a user query.
+
+Task:
+1. Determine how directly, completely, and concisely the generated answer addresses the user's question or intent.
+2. Penalize answers that contain irrelevant tangents, off-topic fluff, or fail to address the core question.
+3. Assign a relevance score between 0.0 (completely irrelevant / non-responsive) and 1.0 (perfectly relevant and directly addresses query intent).
+
+User Query:
+{query}
+
+Generated Answer:
+{answer}
+
+Respond ONLY with a JSON object in this exact schema:
+{{
+  "score": <float between 0.0 and 1.0>,
+  "reasoning": "<concise explanation for the assigned score>"
+}}
+"""
+
+
+def evaluate_faithfulness(
+    query: str,
+    context: str | Sequence[str],
+    answer: str,
+    judge: BaseJudge,
+) -> FaithfulnessResult:
+    """Evaluate whether all factual claims in the answer are grounded in the retrieved context.
+
+    Parameters
+    ----------
+    query:
+        The original user question or prompt.
+    context:
+        Retrieved context chunks (string or list of strings).
+    answer:
+        The generated answer text to evaluate.
+    judge:
+        The pluggable LLM judge instance.
+
+    Returns
+    -------
+    FaithfulnessResult:
+        Contains overall score (0.0 to 1.0), list of verified claims, and reasoning.
+    """
+    if not answer or not answer.strip():
+        return FaithfulnessResult(
+            score=0.0,
+            claims=[],
+            reasoning="Empty answer provided.",
+            supported_count=0,
+            total_count=0,
+        )
+
+    if isinstance(context, str):
+        context_text = context.strip()
+    else:
+        context_text = "\n\n---\n\n".join(c.strip() for c in context if c.strip())
+
+    if not context_text:
+        # If there is an answer but no context, claims cannot be grounded in context
+        return FaithfulnessResult(
+            score=0.0,
+            claims=[
+                ClaimVerification(
+                    claim=answer.strip(),
+                    supported=False,
+                    reasoning="No context provided to ground the answer.",
+                )
+            ],
+            reasoning="Empty context provided; answer cannot be verified.",
+            supported_count=0,
+            total_count=1,
+        )
+
+    prompt = _FAITHFULNESS_PROMPT_TEMPLATE.format(
+        context_text=context_text,
+        query=query.strip() or "N/A",
+        answer=answer.strip(),
+    )
+
+    data = judge.judge_structured(prompt)
+    raw_claims = data.get("claims", [])
+    reasoning = data.get("reasoning", "")
+
+    verifications: list[ClaimVerification] = []
+    supported_count = 0
+
+    if isinstance(raw_claims, list) and raw_claims:
+        for item in raw_claims:
+            if isinstance(item, dict):
+                claim_text = str(item.get("claim", "")).strip()
+                is_supported = bool(item.get("supported", False))
+                c_reason = str(item.get("reasoning", "")).strip()
+                if claim_text:
+                    if is_supported:
+                        supported_count += 1
+                    verifications.append(
+                        ClaimVerification(
+                            claim=claim_text,
+                            supported=is_supported,
+                            reasoning=c_reason,
+                        )
+                    )
+
+    total_count = len(verifications)
+    if total_count > 0:
+        score = supported_count / total_count
+    else:
+        # Fallback to direct score field if claims list was empty
+        score = float(data.get("score", 1.0))
+        score = max(0.0, min(1.0, score))
+
+    return FaithfulnessResult(
+        score=round(score, 4),
+        claims=verifications,
+        reasoning=reasoning,
+        supported_count=supported_count,
+        total_count=total_count,
+    )
+
+
+def evaluate_answer_relevance(
+    query: str,
+    answer: str,
+    judge: BaseJudge,
+) -> AnswerRelevanceResult:
+    """Evaluate how directly and concisely the answer addresses the user query.
+
+    Parameters
+    ----------
+    query:
+        The original user question or prompt.
+    answer:
+        The generated answer text.
+    judge:
+        The pluggable LLM judge instance.
+
+    Returns
+    -------
+    AnswerRelevanceResult:
+        Contains relevance score (0.0 to 1.0) and reasoning.
+    """
+    if not query or not query.strip():
+        return AnswerRelevanceResult(
+            score=0.0,
+            reasoning="Empty query provided.",
+        )
+    if not answer or not answer.strip():
+        return AnswerRelevanceResult(
+            score=0.0,
+            reasoning="Empty answer provided.",
+        )
+
+    prompt = _RELEVANCE_PROMPT_TEMPLATE.format(
+        query=query.strip(),
+        answer=answer.strip(),
+    )
+
+    data = judge.judge_structured(prompt)
+    raw_score = float(data.get("score", 0.0))
+    score = max(0.0, min(1.0, raw_score))
+    reasoning = str(data.get("reasoning", ""))
+
+    return AnswerRelevanceResult(
+        score=round(score, 4),
+        reasoning=reasoning,
+    )
+
+
+def evaluate_rag(
+    query: str,
+    context: str | Sequence[str],
+    answer: str,
+    judge: BaseJudge,
+    run_faithfulness: bool = True,
+    run_answer_relevance: bool = True,
+) -> RAGEvalResult:
+    """Perform combined RAG evaluation (Faithfulness + Answer Relevance).
+
+    Parameters
+    ----------
+    query:
+        The user query text.
+    context:
+        Retrieved context chunks (string or sequence of strings).
+    answer:
+        The generated answer text.
+    judge:
+        The pluggable LLM judge instance.
+    run_faithfulness:
+        Whether to evaluate faithfulness (default True).
+    run_answer_relevance:
+        Whether to evaluate answer relevance (default True).
+
+    Returns
+    -------
+    RAGEvalResult:
+        Contains individual metric results, query, context list, answer, and latency.
+    """
+    ctx_list = [context] if isinstance(context, str) else list(context)
+    t0 = time.perf_counter()
+
+    faithfulness_res = (
+        evaluate_faithfulness(query=query, context=context, answer=answer, judge=judge)
+        if run_faithfulness
+        else None
+    )
+
+    relevance_res = (
+        evaluate_answer_relevance(query=query, answer=answer, judge=judge)
+        if run_answer_relevance
+        else None
+    )
+
+    elapsed_ms = (time.perf_counter() - t0) * 1000.0
+
+    return RAGEvalResult(
+        query=query,
+        context=ctx_list,
+        answer=answer,
+        faithfulness=faithfulness_res,
+        answer_relevance=relevance_res,
+        latency_ms=round(elapsed_ms, 2),
+    )

--- a/src/dynavec/eval/runner.py
+++ b/src/dynavec/eval/runner.py
@@ -1,0 +1,139 @@
+"""Batch dataset evaluation runner for RAG quality benchmarking."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from .base import BaseJudge, RAGEvalResult
+from .metrics import evaluate_rag
+
+
+@dataclass
+class EvalSummary:
+    """Aggregated summary of a batch evaluation run."""
+
+    total_samples: int
+    mean_faithfulness: float
+    mean_relevance: float
+    pass_rate: float
+    pass_threshold: float
+    p95_latency_ms: float
+    results: list[RAGEvalResult] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["results"] = [r.to_dict() for r in self.results]
+        return data
+
+
+class EvalRunner:
+    """Executes evaluation over benchmark datasets and computes summary metrics.
+
+    Parameters
+    ----------
+    judge:
+        The pluggable LLM judge to use for evaluations.
+    pass_threshold:
+        Score threshold (default 0.7) for counting a sample as passing.
+    """
+
+    def __init__(self, judge: BaseJudge, pass_threshold: float = 0.7) -> None:
+        self.judge = judge
+        self.pass_threshold = pass_threshold
+
+    def evaluate_sample(
+        self,
+        query: str,
+        context: str | Sequence[str],
+        answer: str,
+        run_faithfulness: bool = True,
+        run_answer_relevance: bool = True,
+    ) -> RAGEvalResult:
+        """Evaluate a single query-context-answer triplet."""
+        return evaluate_rag(
+            query=query,
+            context=context,
+            answer=answer,
+            judge=self.judge,
+            run_faithfulness=run_faithfulness,
+            run_answer_relevance=run_answer_relevance,
+        )
+
+    def run(
+        self,
+        dataset: Sequence[dict[str, Any] | tuple[str, str | Sequence[str], str]],
+        run_faithfulness: bool = True,
+        run_answer_relevance: bool = True,
+    ) -> EvalSummary:
+        """Evaluate an entire dataset in batch and compute aggregate quality metrics.
+
+        Each item in `dataset` can be:
+        - A dict with keys ``"query"``, ``"context"``, ``"answer"``
+        - A 3-tuple ``(query, context, answer)``
+        """
+        results: list[RAGEvalResult] = []
+        faithfulness_scores: list[float] = []
+        relevance_scores: list[float] = []
+        latencies: list[float] = []
+        passed_count = 0
+
+        for item in dataset:
+            if isinstance(item, dict):
+                q = str(item.get("query", ""))
+                c = item.get("context", [])
+                a = str(item.get("answer", ""))
+            elif isinstance(item, (tuple, list)) and len(item) >= 3:
+                q, c, a = item[0], item[1], item[2]
+            else:
+                continue
+
+            res = self.evaluate_sample(
+                query=q,
+                context=c,
+                answer=a,
+                run_faithfulness=run_faithfulness,
+                run_answer_relevance=run_answer_relevance,
+            )
+            results.append(res)
+            latencies.append(res.latency_ms)
+
+            is_pass = True
+            if res.faithfulness is not None:
+                faithfulness_scores.append(res.faithfulness.score)
+                if res.faithfulness.score < self.pass_threshold:
+                    is_pass = False
+            if res.answer_relevance is not None:
+                relevance_scores.append(res.answer_relevance.score)
+                if res.answer_relevance.score < self.pass_threshold:
+                    is_pass = False
+
+            if is_pass and (res.faithfulness is not None or res.answer_relevance is not None):
+                passed_count += 1
+
+        total = len(results)
+        mean_f = (
+            float(sum(faithfulness_scores) / len(faithfulness_scores))
+            if faithfulness_scores
+            else 0.0
+        )
+        mean_r = float(sum(relevance_scores) / len(relevance_scores)) if relevance_scores else 0.0
+        pass_rate = float(passed_count / total) if total > 0 else 0.0
+
+        # Calculate p95 latency
+        p95_lat = 0.0
+        if latencies:
+            sorted_lat = sorted(latencies)
+            idx = int(0.95 * (len(sorted_lat) - 1))
+            p95_lat = sorted_lat[idx]
+
+        return EvalSummary(
+            total_samples=total,
+            mean_faithfulness=round(mean_f, 4),
+            mean_relevance=round(mean_r, 4),
+            pass_rate=round(pass_rate, 4),
+            pass_threshold=self.pass_threshold,
+            p95_latency_ms=round(p95_lat, 2),
+            results=results,
+        )

--- a/src/dynavec/telemetry.py
+++ b/src/dynavec/telemetry.py
@@ -33,20 +33,16 @@ class TelemetryEvent:
     id: str
     ts: float  # epoch seconds (start)
     op: str  # "search" | "upsert" | "graph_search" | ...
-    ts: float  # epoch seconds (start)
-    op: str  # "search" | "upsert" | "graph_search" | ...
     namespace: str = "default"
     latency_ms: float = 0.0
     n_results: int = 0
     top_k: int | None = None
-    cache_hit: bool | None = None  # None = no cache configured
     cache_hit: bool | None = None  # None = no cache configured
     filtered: bool = False
     rescore: str | None = None
     rerank: str | None = None
     score_top: float | None = None
     score_mean: float | None = None
-    status: str = "ok"  # "ok" | "error"
     status: str = "ok"  # "ok" | "error"
     error: str | None = None
     query_preview: str | None = None  # only set when capture_text=True

--- a/src/dynavec/telemetry.py
+++ b/src/dynavec/telemetry.py
@@ -31,21 +31,27 @@ class TelemetryEvent:
     """A single recorded operation."""
 
     id: str
-    ts: float                      # epoch seconds (start)
-    op: str                        # "search" | "upsert" | "graph_search" | ...
+    ts: float  # epoch seconds (start)
+    op: str  # "search" | "upsert" | "graph_search" | ...
+    ts: float  # epoch seconds (start)
+    op: str  # "search" | "upsert" | "graph_search" | ...
     namespace: str = "default"
     latency_ms: float = 0.0
     n_results: int = 0
     top_k: int | None = None
-    cache_hit: bool | None = None   # None = no cache configured
+    cache_hit: bool | None = None  # None = no cache configured
+    cache_hit: bool | None = None  # None = no cache configured
     filtered: bool = False
     rescore: str | None = None
     rerank: str | None = None
     score_top: float | None = None
     score_mean: float | None = None
-    status: str = "ok"             # "ok" | "error"
+    status: str = "ok"  # "ok" | "error"
+    status: str = "ok"  # "ok" | "error"
     error: str | None = None
     query_preview: str | None = None  # only set when capture_text=True
+    eval_faithfulness: float | None = None  # 0.0-1.0 when LLM judge ran
+    eval_relevance: float | None = None  # 0.0-1.0 when LLM judge ran
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -144,6 +150,9 @@ def aggregate(
     hits = sum(1 for e in cache_scoped if e.cache_hit)
     errors = sum(1 for e in win if e.status == "error")
 
+    faith_scores = [e.eval_faithfulness for e in win if e.eval_faithfulness is not None]
+    rel_scores = [e.eval_relevance for e in win if e.eval_relevance is not None]
+
     op_mix: dict[str, int] = {}
     ns_mix: dict[str, int] = {}
     for e in win:
@@ -170,10 +179,51 @@ def aggregate(
         "cache_total": len(cache_scoped),
         "error_rate": round(100.0 * errors / len(win), 2) if win else 0.0,
         "avg_results": round(sum(e.n_results for e in win) / len(win), 1) if win else 0.0,
+        "eval_faithfulness_mean": round(sum(faith_scores) / len(faith_scores), 4)
+        if faith_scores
+        else None,
+        "eval_relevance_mean": round(sum(rel_scores) / len(rel_scores), 4) if rel_scores else None,
+        "eval_count": max(len(faith_scores), len(rel_scores)),
         "op_mix": op_mix,
         "namespaces": ns_mix,
         "histogram": hist,
         "bucket_width_s": bucket_width,
         "window_start": start,
+        "window_seconds": window_seconds,
+    }
+
+
+def aggregate_eval(
+    events: list[TelemetryEvent],
+    window_seconds: int = 86400,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Summarize evaluation scores across recorded telemetry events."""
+    now = now if now is not None else time.time()
+    start = now - window_seconds
+    win = [e for e in events if e.ts >= start]
+
+    eval_events = [
+        e for e in win if e.eval_faithfulness is not None or e.eval_relevance is not None
+    ]
+    faith_scores = [e.eval_faithfulness for e in eval_events if e.eval_faithfulness is not None]
+    rel_scores = [e.eval_relevance for e in eval_events if e.eval_relevance is not None]
+
+    pass_threshold = 0.7
+    passed = [
+        e
+        for e in eval_events
+        if (e.eval_faithfulness is None or e.eval_faithfulness >= pass_threshold)
+        and (e.eval_relevance is None or e.eval_relevance >= pass_threshold)
+    ]
+
+    return {
+        "total_evals": len(eval_events),
+        "mean_faithfulness": round(sum(faith_scores) / len(faith_scores), 4)
+        if faith_scores
+        else None,
+        "mean_relevance": round(sum(rel_scores) / len(rel_scores), 4) if rel_scores else None,
+        "pass_rate": round(len(passed) / len(eval_events), 4) if eval_events else None,
+        "pass_threshold": pass_threshold,
         "window_seconds": window_seconds,
     }

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,0 +1,526 @@
+"""Comprehensive test suite for dynavec.eval (LLM Judge, Faithfulness, Relevance, Runner, and Dashboard)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dynavec.dashboard import _make_handler
+from dynavec.eval import (
+    AnswerRelevanceResult,
+    CustomJudge,
+    EvalRunner,
+    EvalSummary,
+    FaithfulnessResult,
+    GeminiJudge,
+    MockJudge,
+    OpenAIJudge,
+    RAGEvalResult,
+    evaluate_answer_relevance,
+    evaluate_faithfulness,
+    evaluate_rag,
+    extract_json,
+)
+from dynavec.exceptions import MissingDependencyError
+from dynavec.telemetry import TelemetryRecorder, aggregate, aggregate_eval
+
+# ===========================================================================
+# 1. JSON Extraction Robustness Tests
+# ===========================================================================
+
+
+class TestExtractJson:
+    def test_raw_json(self) -> None:
+        data = extract_json('{"score": 0.95, "reasoning": "great"}')
+        assert data == {"score": 0.95, "reasoning": "great"}
+
+    def test_markdown_json_fence(self) -> None:
+        text = 'Here is the result:\n```json\n{\n  "score": 1.0,\n  "reasoning": "perfect"\n}\n```'
+        data = extract_json(text)
+        assert data == {"score": 1.0, "reasoning": "perfect"}
+
+    def test_markdown_code_fence_no_lang(self) -> None:
+        text = '```\n{\n  "score": 0.8\n}\n```'
+        data = extract_json(text)
+        assert data == {"score": 0.8}
+
+    def test_embedded_json_in_text(self) -> None:
+        text = 'Analysis completed. Result: {"claims": [{"claim": "A", "supported": true}]} End of report.'
+        data = extract_json(text)
+        assert len(data["claims"]) == 1
+        assert data["claims"][0]["supported"] is True
+
+    def test_empty_string_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Empty response"):
+            extract_json("   ")
+
+    def test_invalid_json_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Could not parse valid JSON"):
+            extract_json("This is purely plain text without any braces.")
+
+
+# ===========================================================================
+# 2. Pluggable Judge Implementation Tests
+# ===========================================================================
+
+
+class TestJudges:
+    def test_mock_judge_sequential_and_default(self) -> None:
+        resp1 = {"claims": [{"claim": "c1", "supported": True}], "reasoning": "ok"}
+        resp2 = {"score": 0.9, "reasoning": "relevant"}
+        judge = MockJudge(responses=[resp1, resp2], default_response={"score": 0.5})
+
+        assert judge.judge_structured("prompt 1") == resp1
+        assert judge.judge_structured("prompt 2") == resp2
+        assert judge.judge_structured("prompt 3") == {"score": 0.5}
+        assert len(judge.call_history) == 3
+
+    def test_custom_judge(self) -> None:
+        def fn(p: str) -> str:
+            return json.dumps({"score": 0.85, "reasoning": f"Evaluated {len(p)} chars"})
+
+        judge = CustomJudge(fn)
+        res = judge.judge_structured("hello world")
+        assert res["score"] == 0.85
+
+    def test_custom_judge_non_callable_raises(self) -> None:
+        with pytest.raises(TypeError, match="must be a callable"):
+            CustomJudge("not a function")  # type: ignore[arg-type]
+
+    def test_openai_judge_missing_dep_raises(self) -> None:
+        with patch.dict("sys.modules", {"openai": None}):
+            with pytest.raises(MissingDependencyError) as exc_info:
+                OpenAIJudge()
+            assert "OpenAIJudge" in str(exc_info.value)
+            assert "openai" in str(exc_info.value)
+
+    def test_gemini_judge_missing_dep_raises(self) -> None:
+        with patch.dict("sys.modules", {"google.generativeai": None}):
+            with pytest.raises(MissingDependencyError) as exc_info:
+                GeminiJudge()
+            assert "GeminiJudge" in str(exc_info.value)
+            assert "google-generativeai" in str(exc_info.value)
+
+    def test_openai_judge_mocked_execution(self) -> None:
+        mock_openai_module = MagicMock()
+        mock_client = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = '{"score": 0.99, "reasoning": "perfect"}'
+        mock_client.chat.completions.create.return_value = MagicMock(choices=[mock_choice])
+        mock_openai_module.OpenAI.return_value = mock_client
+
+        with patch.dict("sys.modules", {"openai": mock_openai_module}):
+            judge = OpenAIJudge(model="gpt-4o-mini", api_key="sk-test")
+            result = judge.judge_structured("evaluate this")
+            assert result["score"] == 0.99
+            mock_client.chat.completions.create.assert_called_once()
+
+    def test_gemini_judge_mocked_execution(self) -> None:
+        mock_google = MagicMock()
+        mock_genai_module = MagicMock()
+        mock_google.generativeai = mock_genai_module
+        mock_model = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.text = '{"score": 0.92, "reasoning": "good"}'
+        mock_model.generate_content.return_value = mock_resp
+        mock_genai_module.GenerativeModel.return_value = mock_model
+
+        with patch.dict(
+            "sys.modules", {"google": mock_google, "google.generativeai": mock_genai_module}
+        ):
+            judge = GeminiJudge(model="gemini-1.5-flash", api_key="test-key")
+            result = judge.judge_structured("test prompt")
+            assert result["score"] == 0.92
+            mock_genai_module.configure.assert_called_once_with(api_key="test-key")
+
+
+# ===========================================================================
+# 3. Faithfulness Metric Evaluation Tests
+# ===========================================================================
+
+
+class TestFaithfulnessMetric:
+    def test_perfect_faithfulness(self) -> None:
+        judge_output = {
+            "claims": [
+                {
+                    "claim": "Dynavec uses S3 Vectors for ANN.",
+                    "supported": True,
+                    "reasoning": "Direct match.",
+                },
+                {
+                    "claim": "Dynavec stores docs in DynamoDB.",
+                    "supported": True,
+                    "reasoning": "Direct match.",
+                },
+            ],
+            "reasoning": "All claims grounded.",
+        }
+        judge = MockJudge(default_response=judge_output)
+
+        res = evaluate_faithfulness(
+            query="How does dynavec work?",
+            context=["Dynavec uses S3 Vectors for ANN and DynamoDB for document storage."],
+            answer="Dynavec uses S3 Vectors for ANN. Dynavec stores docs in DynamoDB.",
+            judge=judge,
+        )
+
+        assert res.score == 1.0
+        assert res.supported_count == 2
+        assert res.total_count == 2
+        assert len(res.claims) == 2
+        assert res.reasoning == "All claims grounded."
+
+    def test_partial_hallucination(self) -> None:
+        judge_output = {
+            "claims": [
+                {"claim": "Dynavec uses S3 Vectors.", "supported": True, "reasoning": "Supported."},
+                {
+                    "claim": "Dynavec was created in 1995.",
+                    "supported": False,
+                    "reasoning": "Not mentioned.",
+                },
+            ],
+            "reasoning": "Half of the claims are hallucinated.",
+        }
+        judge = MockJudge(default_response=judge_output)
+
+        res = evaluate_faithfulness(
+            query="What is dynavec?",
+            context="Dynavec uses S3 Vectors for search.",
+            answer="Dynavec uses S3 Vectors and was created in 1995.",
+            judge=judge,
+        )
+
+        assert res.score == 0.5
+        assert res.supported_count == 1
+        assert res.total_count == 2
+        assert res.claims[1].supported is False
+
+    def test_complete_hallucination(self) -> None:
+        judge_output = {
+            "claims": [
+                {"claim": "Paris is in Germany.", "supported": False, "reasoning": "Contradicted."},
+            ],
+            "reasoning": "Entire answer is false.",
+        }
+        judge = MockJudge(default_response=judge_output)
+
+        res = evaluate_faithfulness(
+            query="Where is Paris?",
+            context="Paris is the capital of France.",
+            answer="Paris is in Germany.",
+            judge=judge,
+        )
+
+        assert res.score == 0.0
+        assert res.supported_count == 0
+        assert res.total_count == 1
+
+    def test_empty_answer(self) -> None:
+        judge = MockJudge()
+        res = evaluate_faithfulness(
+            query="Any query",
+            context=["Context chunk"],
+            answer="",
+            judge=judge,
+        )
+        assert res.score == 0.0
+        assert len(res.claims) == 0
+        assert "Empty answer" in res.reasoning
+
+    def test_empty_context(self) -> None:
+        judge = MockJudge()
+        res = evaluate_faithfulness(
+            query="Any query",
+            context=[],
+            answer="Dynavec is fast.",
+            judge=judge,
+        )
+        assert res.score == 0.0
+        assert len(res.claims) == 1
+        assert res.claims[0].supported is False
+        assert "Empty context" in res.reasoning
+
+
+# ===========================================================================
+# 4. Answer Relevance Metric Evaluation Tests
+# ===========================================================================
+
+
+class TestAnswerRelevanceMetric:
+    def test_high_relevance(self) -> None:
+        judge = MockJudge(
+            default_response={"score": 0.95, "reasoning": "Direct and concise answer."}
+        )
+        res = evaluate_answer_relevance(
+            query="How much does dynavec cost?",
+            answer="Dynavec is serverless and costs around $3/mo for base DynamoDB + S3 Vectors.",
+            judge=judge,
+        )
+        assert res.score == 0.95
+        assert res.reasoning == "Direct and concise answer."
+
+    def test_low_relevance_off_topic(self) -> None:
+        judge = MockJudge(
+            default_response={
+                "score": 0.1,
+                "reasoning": "Answer discusses weather instead of pricing.",
+            }
+        )
+        res = evaluate_answer_relevance(
+            query="How much does dynavec cost?",
+            answer="The weather in Seattle is rainy today.",
+            judge=judge,
+        )
+        assert res.score == 0.1
+
+    def test_empty_query_or_answer(self) -> None:
+        judge = MockJudge()
+        assert evaluate_answer_relevance(query="", answer="test", judge=judge).score == 0.0
+        assert evaluate_answer_relevance(query="test", answer="", judge=judge).score == 0.0
+
+
+# ===========================================================================
+# 5. Combined evaluate_rag & EvalRunner Tests
+# ===========================================================================
+
+
+class TestEvalRunner:
+    def test_evaluate_rag_combined(self) -> None:
+        f_resp = {
+            "claims": [{"claim": "Fact 1", "supported": True}],
+            "reasoning": "Grounded",
+        }
+        r_resp = {"score": 0.9, "reasoning": "Relevant"}
+        judge = MockJudge(responses=[f_resp, r_resp])
+
+        rag_res = evaluate_rag(
+            query="What is dynavec?",
+            context=["Dynavec is a vector DB."],
+            answer="Dynavec is a vector DB.",
+            judge=judge,
+        )
+
+        assert isinstance(rag_res, RAGEvalResult)
+        assert rag_res.faithfulness is not None
+        assert rag_res.faithfulness.score == 1.0
+        assert rag_res.answer_relevance is not None
+        assert rag_res.answer_relevance.score == 0.9
+        assert rag_res.latency_ms >= 0.0
+
+        d = rag_res.to_dict()
+        assert d["query"] == "What is dynavec?"
+        assert d["faithfulness"]["score"] == 1.0
+
+    def test_eval_runner_batch_dataset(self) -> None:
+        # Sample 1: Faithful (1.0) & Relevant (0.9) -> Pass
+        # Sample 2: Partial (0.5) & Relevant (0.8) -> Fail (since pass_threshold=0.7)
+        resp1_f = {"claims": [{"claim": "c1", "supported": True}]}
+        resp1_r = {"score": 0.9}
+        resp2_f = {
+            "claims": [{"claim": "c2", "supported": True}, {"claim": "c3", "supported": False}]
+        }
+        resp2_r = {"score": 0.8}
+
+        judge = MockJudge(responses=[resp1_f, resp1_r, resp2_f, resp2_r])
+        runner = EvalRunner(judge=judge, pass_threshold=0.7)
+
+        dataset = [
+            {
+                "query": "Q1",
+                "context": ["C1"],
+                "answer": "A1",
+            },
+            ("Q2", ["C2"], "A2"),
+        ]
+
+        summary = runner.run(dataset)
+        assert isinstance(summary, EvalSummary)
+        assert summary.total_samples == 2
+        assert summary.mean_faithfulness == pytest.approx(0.75)
+        assert summary.mean_relevance == pytest.approx(0.85)
+        assert summary.pass_rate == 0.5  # 1 of 2 passed
+        assert summary.pass_threshold == 0.7
+        assert len(summary.results) == 2
+
+        summary_dict = summary.to_dict()
+        assert summary_dict["total_samples"] == 2
+        assert len(summary_dict["results"]) == 2
+
+
+# ===========================================================================
+# 6. Telemetry & Dashboard API Integration Tests
+# ===========================================================================
+
+
+class TestTelemetryAndDashboardIntegration:
+    def test_telemetry_event_eval_fields(self) -> None:
+        rec = TelemetryRecorder()
+        ev = rec.new_event(
+            op="search",
+            namespace="default",
+            latency_ms=42.0,
+            eval_faithfulness=0.95,
+            eval_relevance=0.88,
+        )
+        rec.record(ev)
+
+        assert ev.eval_faithfulness == 0.95
+        assert ev.eval_relevance == 0.88
+        d = ev.to_dict()
+        assert d["eval_faithfulness"] == 0.95
+        assert d["eval_relevance"] == 0.88
+
+    def test_aggregate_includes_eval_means(self) -> None:
+        rec = TelemetryRecorder()
+        rec.record(rec.new_event("search", eval_faithfulness=1.0, eval_relevance=0.9))
+        rec.record(rec.new_event("search", eval_faithfulness=0.8, eval_relevance=0.7))
+        rec.record(rec.new_event("search"))  # unevaluated event
+
+        stats = aggregate(rec.snapshot())
+        assert stats["eval_faithfulness_mean"] == 0.9
+        assert stats["eval_relevance_mean"] == 0.8
+        assert stats["eval_count"] == 2
+
+    def test_aggregate_eval_function(self) -> None:
+        rec = TelemetryRecorder()
+        rec.record(rec.new_event("search", eval_faithfulness=1.0, eval_relevance=0.9))  # pass
+        rec.record(rec.new_event("search", eval_faithfulness=0.5, eval_relevance=0.8))  # fail
+        rec.record(rec.new_event("upsert"))  # ignored by eval aggregation
+
+        summary = aggregate_eval(rec.snapshot())
+        assert summary["total_evals"] == 2
+        assert summary["mean_faithfulness"] == 0.75
+        assert summary["mean_relevance"] == 0.85
+        assert summary["pass_rate"] == 0.5
+
+    def test_dashboard_api_eval_endpoints(self) -> None:
+        rec = TelemetryRecorder()
+        rec.record(
+            rec.new_event(
+                "search",
+                namespace="kb",
+                latency_ms=50.0,
+                eval_faithfulness=0.92,
+                eval_relevance=0.85,
+            )
+        )
+
+        handler_cls = _make_handler(rec)
+        handler = handler_cls.__new__(handler_cls)
+        handler.wfile = MagicMock()
+        sent_data = {}
+
+        def mock_send(code, body, ctype="application/json"):
+            sent_data["code"] = code
+            sent_data["body"] = json.loads(body)
+            sent_data["ctype"] = ctype
+
+        handler._send = mock_send
+
+        # Test GET /api/eval/summary
+        handler.path = "/api/eval/summary"
+        handler.do_GET()
+        assert sent_data["code"] == 200
+        assert sent_data["body"]["total_evals"] == 1
+        assert sent_data["body"]["mean_faithfulness"] == 0.92
+
+        # Test GET /api/eval/runs
+        handler.path = "/api/eval/runs"
+        handler.do_GET()
+        assert sent_data["code"] == 200
+        assert len(sent_data["body"]) == 1
+        assert sent_data["body"][0]["eval_faithfulness"] == 0.92
+        assert sent_data["body"][0]["eval_relevance"] == 0.85
+
+
+# ===========================================================================
+# 7. Visual Charting Tests
+# ===========================================================================
+
+
+class TestPlotEvalSummary:
+    def test_plot_eval_summary_missing_dep_raises(self) -> None:
+        from dynavec.eval import EvalSummary, plot_eval_summary
+
+        summary = EvalSummary(
+            total_samples=1,
+            mean_faithfulness=0.9,
+            mean_relevance=0.8,
+            pass_rate=1.0,
+            pass_threshold=0.7,
+            p95_latency_ms=10.0,
+            results=[
+                RAGEvalResult(
+                    query="Q",
+                    context=["C"],
+                    answer="A",
+                    faithfulness=FaithfulnessResult(score=0.9),
+                    answer_relevance=AnswerRelevanceResult(score=0.8),
+                )
+            ],
+        )
+
+        with patch.dict("sys.modules", {"matplotlib": None}):
+            with pytest.raises(MissingDependencyError) as exc_info:
+                plot_eval_summary(summary)
+            assert "matplotlib" in str(exc_info.value)
+            assert "benchmark" in str(exc_info.value)
+
+    def test_plot_eval_summary_mocked_generation(self) -> None:
+        from dynavec.eval import EvalSummary, plot_eval_summary
+
+        r1 = RAGEvalResult(
+            query="Q1",
+            context=["C1"],
+            answer="A1",
+            faithfulness=FaithfulnessResult(score=0.9, supported_count=1, total_count=1),
+            answer_relevance=AnswerRelevanceResult(score=0.85),
+            latency_ms=10.0,
+        )
+
+        summary = EvalSummary(
+            total_samples=1,
+            mean_faithfulness=0.9,
+            mean_relevance=0.85,
+            pass_rate=1.0,
+            pass_threshold=0.7,
+            p95_latency_ms=10.0,
+            results=[r1],
+        )
+
+        mock_fig = MagicMock()
+        mock_ax = MagicMock()
+        mock_plt = MagicMock()
+        mock_plt.subplots.return_value = (mock_fig, mock_ax)
+        mock_matplotlib = MagicMock()
+        mock_matplotlib.pyplot = mock_plt
+
+        with patch.dict(
+            "sys.modules", {"matplotlib": mock_matplotlib, "matplotlib.pyplot": mock_plt}
+        ):
+            saved_path = plot_eval_summary(summary, output_path="out.png")
+            assert saved_path == "out.png"
+            mock_plt.savefig.assert_called_once_with("out.png", bbox_inches="tight")
+            mock_plt.close.assert_called_once_with(mock_fig)
+
+    def test_plot_eval_summary_empty_results_raises(self) -> None:
+        from dynavec.eval import EvalSummary, plot_eval_summary
+
+        empty_summary = EvalSummary(
+            total_samples=0,
+            mean_faithfulness=0.0,
+            mean_relevance=0.0,
+            pass_rate=0.0,
+            pass_threshold=0.7,
+            p95_latency_ms=0.0,
+            results=[],
+        )
+
+        mock_plt = MagicMock()
+        with patch.dict("sys.modules", {"matplotlib": MagicMock(), "matplotlib.pyplot": mock_plt}):
+            with pytest.raises(ValueError, match="Cannot plot empty evaluation results"):
+                plot_eval_summary(empty_summary)


### PR DESCRIPTION
Closes #135

### Summary

Implements the pluggable **LLM-as-a-Judge** evaluation framework for RAG workflows as outlined in the issue plan:

- **Pluggable Judge (`src/dynavec/eval/`):** `BaseJudge` interface with `OpenAIJudge`, `BedrockJudge`, `GeminiJudge`, `CustomJudge`, and `MockJudge`, featuring resilient JSON extraction and lazy dependency imports.
- **Faithfulness & Relevance Metrics:** Claim-entailment faithfulness scoring ($\text{supported} / \text{total}$), question-intent relevance evaluation, batch `EvalRunner`, and visual scatter plotting (`plot_eval_summary`).
- **Telemetry & Dashboard API:** Integrated evaluation metrics into `TelemetryRecorder` / `TelemetryEvent` and exposed `/api/eval/summary` + `/api/eval/runs` endpoints for the Observability Dashboard.
- **Testing:** 30 comprehensive unit tests in `tests/test_eval.py` (285 passed full suite, 0 lint errors).

---
Open to any feedback or adjustments. Looking forward to your review!