### PR TITLE
feat(embeddings): add Ollama local embedder (Closes #5)

### DIFF
--- a/src/dynavec/embeddings/__init__.py
+++ b/src/dynavec/embeddings/__init__.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:  # for type checkers / IDEs only
     from .bedrock import BedrockEmbedder, BedrockTitanMultimodalEmbedder
     from .gemini import GeminiEmbedder
     from .mistral import MistralEmbedder
+    from .ollama import OllamaEmbedder
     from .openai import OpenAIEmbedder
     from .sentence_transformers import SentenceTransformerEmbedder
     from .voyage import VoyageEmbedder
@@ -29,6 +30,7 @@ __all__ = [
     "SentenceTransformerEmbedder",
     "VoyageEmbedder",
     "MistralEmbedder",
+    "OllamaEmbedder",
 ]
 
 _LAZY = {
@@ -45,6 +47,7 @@ _LAZY = {
     ),
     "VoyageEmbedder": ("dynavec.embeddings.voyage", "VoyageEmbedder"),
     "MistralEmbedder": ("dynavec.embeddings.mistral", "MistralEmbedder"),
+    "OllamaEmbedder": ("dynavec.embeddings.ollama", "OllamaEmbedder"),
 }
 
 

--- a/src/dynavec/embeddings/ollama.py
+++ b/src/dynavec/embeddings/ollama.py
@@ -1,0 +1,93 @@
+"""Ollama local embedder (hits local Ollama HTTP API)."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+from .base import Embedder, Vector
+
+# Known output dimensions for common Ollama embedding models
+_MODEL_DIMS = {
+    "nomic-embed-text": 768,
+    "all-minilm": 384,
+    "bge-m3": 1024,
+    "mxbai-embed-large": 1024,
+    "snowflake-arctic-embed": 1024,
+}
+
+
+class OllamaEmbedder(Embedder):
+    """Embeds text locally using an Ollama server's embedding API.
+
+    Parameters
+    ----------
+    model:
+        Ollama model name, e.g. ``"nomic-embed-text"``.
+    host:
+        Ollama server base URL. Optional; defaults to the ``OLLAMA_HOST`` environment
+        variable or ``"http://localhost:11434"``.
+    dimension:
+        Optional override for output vector dimension. Inferred from known model defaults
+        or first API response if omitted.
+    batch_size:
+        Number of texts per embedding request. Defaults to 64.
+    timeout:
+        Request timeout in seconds. Defaults to 30.
+    """
+
+    def __init__(
+        self,
+        model: str = "nomic-embed-text",
+        host: str | None = None,
+        dimension: int | None = None,
+        batch_size: int = 64,
+        timeout: float = 30.0,
+    ) -> None:
+        self.model = model
+        base_host = host or os.environ.get("OLLAMA_HOST") or "http://localhost:11434"
+        self.host = base_host.rstrip("/")
+        self._requested_dim = dimension
+        self.dimension = dimension or _MODEL_DIMS.get(model, 768)
+        self.batch_size = batch_size
+        self.timeout = timeout
+
+    def _post(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
+        url = f"{self.host}{endpoint}"
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            url,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"Ollama embedding request failed ({url}): {exc}") from exc
+
+    def embed_documents(self, texts: list[str]) -> list[Vector]:
+        if not texts:
+            return []
+
+        out: list[Vector] = []
+        for i in range(0, len(texts), self.batch_size):
+            chunk = texts[i : i + self.batch_size]
+            payload = {"model": self.model, "input": chunk}
+            res = self._post("/api/embed", payload)
+            embeddings = res.get("embeddings", [])
+            out.extend(embeddings)
+
+        if (
+            out
+            and self._requested_dim is None
+            and self.dimension == 768
+            and self.model not in _MODEL_DIMS
+        ):
+            self.dimension = len(out[0])
+
+        return out

--- a/tests/test_ollama_embedder.py
+++ b/tests/test_ollama_embedder.py
@@ -1,0 +1,118 @@
+"""Unit tests for OllamaEmbedder."""
+
+import json
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dynavec.embeddings import OllamaEmbedder
+
+
+def _fake_urlopen_response(data: dict):
+    body = json.dumps(data).encode("utf-8")
+    resp = MagicMock()
+    resp.read.return_value = body
+    resp.__enter__.return_value = resp
+    return resp
+
+
+def test_import_lazy():
+    from dynavec.embeddings import OllamaEmbedder as Exported
+    from dynavec.embeddings.ollama import OllamaEmbedder as Direct
+
+    assert Exported is Direct
+
+
+def test_default_parameters(monkeypatch):
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    emb = OllamaEmbedder()
+    assert emb.host == "http://localhost:11434"
+    assert emb.model == "nomic-embed-text"
+    assert emb.dimension == 768
+    assert emb.batch_size == 64
+
+
+def test_custom_host_and_model():
+    emb = OllamaEmbedder(host="http://my-ollama:11434/", model="all-minilm")
+    assert emb.host == "http://my-ollama:11434"
+    assert emb.model == "all-minilm"
+    assert emb.dimension == 384
+
+
+def test_env_var_host(monkeypatch):
+    monkeypatch.setenv("OLLAMA_HOST", "http://ollama-env:11434")
+    emb = OllamaEmbedder()
+    assert emb.host == "http://ollama-env:11434"
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_dim"),
+    [
+        ("nomic-embed-text", 768),
+        ("all-minilm", 384),
+        ("bge-m3", 1024),
+        ("mxbai-embed-large", 1024),
+        ("snowflake-arctic-embed", 1024),
+        ("unknown-model", 768),
+    ],
+)
+def test_model_dimensions(model, expected_dim):
+    assert OllamaEmbedder(model=model).dimension == expected_dim
+
+
+def test_explicit_dimension_override():
+    emb = OllamaEmbedder(model="nomic-embed-text", dimension=512)
+    assert emb.dimension == 512
+
+
+@patch("urllib.request.urlopen")
+def test_embed_documents(mock_urlopen):
+    mock_urlopen.return_value = _fake_urlopen_response(
+        {"embeddings": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]}
+    )
+    emb = OllamaEmbedder(host="http://localhost:11434", model="nomic-embed-text")
+    res = emb.embed_documents(["hello", "world"])
+
+    assert res == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+    assert mock_urlopen.call_count == 1
+    req = mock_urlopen.call_args[0][0]
+    assert req.full_url == "http://localhost:11434/api/embed"
+    assert req.method == "POST"
+    payload = json.loads(req.data.decode("utf-8"))
+    assert payload == {"model": "nomic-embed-text", "input": ["hello", "world"]}
+
+
+@patch("urllib.request.urlopen")
+def test_embed_query(mock_urlopen):
+    mock_urlopen.return_value = _fake_urlopen_response({"embeddings": [[0.1, 0.2, 0.3]]})
+    emb = OllamaEmbedder()
+    res = emb.embed_query("query text")
+
+    assert res == [0.1, 0.2, 0.3]
+
+
+@patch("urllib.request.urlopen")
+def test_batching(mock_urlopen):
+    mock_urlopen.side_effect = [
+        _fake_urlopen_response({"embeddings": [[0.1], [0.2]]}),
+        _fake_urlopen_response({"embeddings": [[0.3]]}),
+    ]
+    emb = OllamaEmbedder(batch_size=2)
+    res = emb.embed_documents(["a", "b", "c"])
+
+    assert res == [[0.1], [0.2], [0.3]]
+    assert mock_urlopen.call_count == 2
+
+
+def test_empty_input():
+    emb = OllamaEmbedder()
+    assert emb.embed_documents([]) == []
+
+
+@patch("urllib.request.urlopen")
+def test_http_error_handling(mock_urlopen):
+    mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
+    emb = OllamaEmbedder()
+    with pytest.raises(RuntimeError, match="Ollama embedding request failed"):
+        emb.embed_documents(["test"])


### PR DESCRIPTION
## Description
Implemented a **local Ollama embedder** for the `dynavec` library. This new embedder allows users to generate text embeddings via a locally‑hosted Ollama server without adding heavy external dependencies. The implementation follows the existing embedder architecture, uses lazy loading to keep the base install lightweight, and includes comprehensive unit tests.

## Related issue
Fixes **[#5](https://github.com/codeforstartups/dynavec/issues/5)** – *Add Ollama local embedder*.

## Changes
- **Added** `src/dynavec/embeddings/ollama.py` – new `OllamaEmbedder` class that communicates with Ollama over HTTP using the standard library.
- **Updated** `src/dynavec/embeddings/__init__.py` – registered `OllamaEmbedder` in the lazy‑loading `_LAZY` dictionary.
- **Added** `tests/test_ollama_embedder.py` – mock‑based unit tests covering initialization, request formation, and response handling for the new embedder.
- **Documentation** (in‑code docstrings) describing usage and environment requirements for the Ollama embedder.

## Testing
- [x] **Tests pass locally** – `pytest -q` reports **271 passed** (including the new 16 Ollama tests).
- [x] **Ruff checks pass** – `ruff check .` reports no violations.
- [ ] **Documentation updated**, if applicable – the embedder’s public API is documented via docstrings; no external README changes were required for this feature.

## Checklist
- [x] My changes are focused and relevant to this pull request.  
- [x] I have added or updated tests where appropriate.  
- [x] I have reviewed my changes for unrelated modifications.  
- [ ] I have updated documentation where necessary. *(Only in‑code docs were added; no external docs needed.)*  