### PR TITLE
feat: add URL ingestion source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install (with dev extras)
-        run: uv pip install -e ".[dev]"
+        run: uv pip install -e ".[dev,ingest]"
       - name: Lint
         run: uv run --no-sync ruff check src benchmarks
       - name: Test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ rerank = ["sentence-transformers>=3.0"]         # cross-encoder reranking
 redis = ["redis>=5.0"]                            # RedisCache / AWS ElastiCache
 mcp = ["mcp>=1.0; python_version >= '3.10'"]       # MCP client ingestion
 pinecone = ["pinecone>=5.0"]                      # for benchmarks/examples comparison
-ingest = ["pypdf>=4.0", "python-docx>=1.1", "python-pptx>=0.6", "openpyxl>=3.1"]
+ingest = ["pypdf>=4.0", "python-docx>=1.1", "python-pptx>=0.6", "openpyxl>=3.1","beautifulsoup4>=4.12",]
 
 # --- Agent framework integrations ---
 langchain = ["langchain-core>=0.3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ rerank = ["sentence-transformers>=3.0"]         # cross-encoder reranking
 redis = ["redis>=5.0"]                            # RedisCache / AWS ElastiCache
 mcp = ["mcp>=1.0; python_version >= '3.10'"]       # MCP client ingestion
 pinecone = ["pinecone>=5.0"]                      # for benchmarks/examples comparison
-ingest = ["pypdf>=4.0", "python-docx>=1.1", "python-pptx>=0.6", "openpyxl>=3.1","beautifulsoup4>=4.12",]
+ingest = ["pypdf>=4.0", "python-docx>=1.1", "python-pptx>=0.6", "openpyxl>=3.1","beautifulsoup4>=4.12","requests>=2.31",]
 
 # --- Agent framework integrations ---
 langchain = ["langchain-core>=0.3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,7 @@ rerank = ["sentence-transformers>=3.0"]         # cross-encoder reranking
 redis = ["redis>=5.0"]                            # RedisCache / AWS ElastiCache
 mcp = ["mcp>=1.0; python_version >= '3.10'"]       # MCP client ingestion
 pinecone = ["pinecone>=5.0"]                      # for benchmarks/examples comparison
-<<<<<<< HEAD
-ingest = ["pypdf>=4.0", "python-docx>=1.1", "python-pptx>=0.6", "openpyxl>=3.1", "beautifulsoup4>=4.12", "requests>=2.31",]
-=======
-ingest = ["pypdf>=4.0", "python-docx>=1.1", "python-pptx>=0.6", "openpyxl>=3.1", "PyYAML>=6.0"]
->>>>>>> upstream/development
+ingest = ["pypdf>=4.0", "python-docx>=1.1", "python-pptx>=0.6", "openpyxl>=3.1", "beautifulsoup4>=4.12", "requests>=2.31", "PyYAML>=6.0",]
 
 # --- Agent framework integrations ---
 langchain = ["langchain-core>=0.3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ rerank = ["sentence-transformers>=3.0"]         # cross-encoder reranking
 redis = ["redis>=5.0"]                            # RedisCache / AWS ElastiCache
 mcp = ["mcp>=1.0; python_version >= '3.10'"]       # MCP client ingestion
 pinecone = ["pinecone>=5.0"]                      # for benchmarks/examples comparison
-ingest = ["pypdf>=4.0", "python-docx>=1.1", "python-pptx>=0.6", "openpyxl>=3.1","beautifulsoup4>=4.12","requests>=2.31",]
+ingest = ["pypdf>=4.0", "python-docx>=1.1", "python-pptx>=0.6", "openpyxl>=3.1", "beautifulsoup4>=4.12", "requests>=2.31",]
 
 # --- Agent framework integrations ---
 langchain = ["langchain-core>=0.3"]

--- a/src/dynavec/ingest.py
+++ b/src/dynavec/ingest.py
@@ -27,6 +27,8 @@ from .exceptions import MissingDependencyError
 from .models import Document
 from .utils import chunked
 
+import requests
+
 Metadata = dict[str, Any]
 
 
@@ -104,6 +106,40 @@ class PDFSource:
                 },
             )
 
+class URLSource:
+    """Yield one Record containing readable text extracted from a URL."""
+    def __init__(self, url: str, timeout: float=10)->None:
+        try:
+            from bs4 import BeautifulSoup
+        except ImportError as exc:
+            raise MissingDependencyError(
+                "URLSource",
+                "beautifulsoup4",
+                "ingest"
+            ) from exc
+        self._url= url
+        self._timeout= timeout
+        self._parser_cls= BeautifulSoup
+    
+    def __iter__(self)-> Iterator[Record]:
+        response=requests.get(
+            self._url,
+            timeout=self._timeout)
+        response.raise_for_status()
+        soup=self._parser_cls(response.text,"html.parser")  
+        for tag in soup(["script","style"]):
+            tag.decompose()
+        page_text=soup.get_text(separator=" ",strip=True)
+        if not page_text:
+            return
+        yield Record(
+            id= self._url,
+            text= page_text,
+            metadata={
+                "source": "url",
+                "url": self._url
+                },
+            )
 
 class MCPResourceSource:
     """Adapt an MCP server's *resources* into dynavec records.

--- a/src/dynavec/ingest.py
+++ b/src/dynavec/ingest.py
@@ -22,12 +22,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+import requests
+
 from .client import Dynavec
 from .exceptions import MissingDependencyError
 from .models import Document
 from .utils import chunked
 
-import requests
+
 
 Metadata = dict[str, Any]
 

--- a/src/dynavec/ingest.py
+++ b/src/dynavec/ingest.py
@@ -124,7 +124,9 @@ class URLSource:
     def __iter__(self)-> Iterator[Record]:
         response=requests.get(
             self._url,
-            timeout=self._timeout)
+            timeout=self._timeout,
+            headers={"User-Agent": "dynavec/1.0"},
+        )
         response.raise_for_status()
         soup=self._parser_cls(response.text,"html.parser")  
         for tag in soup(["script","style"]):

--- a/src/dynavec/ingest.py
+++ b/src/dynavec/ingest.py
@@ -29,8 +29,6 @@ from .exceptions import MissingDependencyError
 from .models import Document
 from .utils import chunked
 
-
-
 Metadata = dict[str, Any]
 
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -126,6 +126,7 @@ def test_url_source_yields_readable_text(monkeypatch):
 
 
 def test_url_source_raises_for_http_error(monkeypatch):
+    import pytest
     class FakeResponse:
         text = ""
 
@@ -139,6 +140,24 @@ def test_url_source_raises_for_http_error(monkeypatch):
 
     with pytest.raises(requests.HTTPError):
         list(URLSource("https://example.com/missing"))
+
+
+def test_url_source_skips_empty_pages(monkeypatch):
+    class FakeResponse:
+        text = "<html><body></body></html>"
+
+        def raise_for_status(self):
+            pass
+
+    def fake_get(url, timeout):
+        return FakeResponse()
+
+    monkeypatch.setattr("dynavec.ingest.requests.get", fake_get)
+
+    records = list(URLSource("https://example.com"))
+
+    assert records == []
+
 # ---- fake MCP session mirroring the SDK's list_resources / read_resource ----
 class _Res:
     def __init__(self, uri, name):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -159,22 +159,6 @@ def test_url_source_skips_empty_pages(monkeypatch):
     assert records == []
 
 
-def test_url_source_skips_empty_pages(monkeypatch):
-    class FakeResponse:
-        text = "<html><body></body></html>"
-
-        def raise_for_status(self):
-            pass
-
-    def fake_get(url, timeout):
-        return FakeResponse()
-
-    monkeypatch.setattr("dynavec.ingest.requests.get", fake_get)
-
-    records = list(URLSource("https://example.com"))
-
-    assert records == []
-
 # ---- fake MCP session mirroring the SDK's list_resources / read_resource ----
 class _Res:
     def __init__(self, uri, name):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -150,7 +150,7 @@ def test_url_source_skips_empty_pages(monkeypatch):
         def raise_for_status(self):
             pass
 
-    def fake_get(url, timeout):
+    def fake_get(url, timeout, headers):
         return FakeResponse()
 
     monkeypatch.setattr("dynavec.ingest.requests.get", fake_get)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -134,7 +134,7 @@ def test_url_source_raises_for_http_error(monkeypatch):
         def raise_for_status(self):
             raise requests.HTTPError("404 Not Found")
 
-    def fake_get(url, timeout):
+    def fake_get(url, timeout, headers):
         return FakeResponse()
 
     monkeypatch.setattr("dynavec.ingest.requests.get", fake_get)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -124,6 +124,21 @@ def test_url_source_yields_readable_text(monkeypatch):
         "url": "https://example.com",
     }
 
+
+def test_url_source_raises_for_http_error(monkeypatch):
+    class FakeResponse:
+        text = ""
+
+        def raise_for_status(self):
+            raise requests.HTTPError("404 Not Found")
+
+    def fake_get(url, timeout):
+        return FakeResponse()
+
+    monkeypatch.setattr("dynavec.ingest.requests.get", fake_get)
+
+    with pytest.raises(requests.HTTPError):
+        list(URLSource("https://example.com/missing"))
 # ---- fake MCP session mirroring the SDK's list_resources / read_resource ----
 class _Res:
     def __init__(self, uri, name):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -4,8 +4,10 @@ import sys
 from types import SimpleNamespace
 
 from dynavec.exceptions import MissingDependencyError
-from dynavec.ingest import MCPResourceSource, PDFSource, Record, chunk_text, ingest
+from dynavec.ingest import MCPResourceSource, PDFSource, URLSource, Record, chunk_text, ingest
 from dynavec.models import UpsertResult
+
+import requests
 
 
 def test_chunk_text_windows_with_overlap():
@@ -82,6 +84,45 @@ def test_pdf_source_missing_dependency(monkeypatch):
     with pytest.raises(MissingDependencyError, match=r"dynavec\[ingest\]"):
         PDFSource("sample.pdf")
 
+
+
+def test_url_source_yields_readable_text(monkeypatch):
+    class FakeResponse:
+        text = """
+        <html>
+            <head>
+                <script>alert("ignore me")</script>
+                <style>body { color: red; }</style>
+            </head>
+            <body>
+                <h1>Hello Dynavec</h1>
+                <p>This is useful content.</p>
+            </body>
+        </html>
+        """
+
+        def raise_for_status(self):
+            pass
+
+    def fake_get(url, timeout):
+        assert url == "https://example.com"
+        assert timeout == 10
+        return FakeResponse()
+
+    monkeypatch.setattr("dynavec.ingest.requests.get", fake_get)
+
+    records = list(URLSource("https://example.com"))
+
+    assert len(records) == 1
+    assert records[0].id == "https://example.com"
+    assert "Hello Dynavec" in records[0].text
+    assert "This is useful content." in records[0].text
+    assert "alert" not in records[0].text
+    assert "color: red" not in records[0].text
+    assert records[0].metadata == {
+        "source": "url",
+        "url": "https://example.com",
+    }
 
 # ---- fake MCP session mirroring the SDK's list_resources / read_resource ----
 class _Res:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -158,6 +158,23 @@ def test_url_source_skips_empty_pages(monkeypatch):
 
     assert records == []
 
+
+def test_url_source_skips_empty_pages(monkeypatch):
+    class FakeResponse:
+        text = "<html><body></body></html>"
+
+        def raise_for_status(self):
+            pass
+
+    def fake_get(url, timeout):
+        return FakeResponse()
+
+    monkeypatch.setattr("dynavec.ingest.requests.get", fake_get)
+
+    records = list(URLSource("https://example.com"))
+
+    assert records == []
+
 # ---- fake MCP session mirroring the SDK's list_resources / read_resource ----
 class _Res:
     def __init__(self, uri, name):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -104,9 +104,10 @@ def test_url_source_yields_readable_text(monkeypatch):
         def raise_for_status(self):
             pass
 
-    def fake_get(url, timeout):
+    def fake_get(url, timeout, headers):
         assert url == "https://example.com"
         assert timeout == 10
+        assert headers["User-Agent"] == "dynavec/1.0"
         return FakeResponse()
 
     monkeypatch.setattr("dynavec.ingest.requests.get", fake_get)


### PR DESCRIPTION
## Summary

Add URL ingestion support for fetching HTML pages, extracting readable text, and passing the content through Dynavec's existing ingestion pipeline.

## Changes

- Add `URLSource` for fetching HTML pages
- Extract readable page text using BeautifulSoup
- Remove `<script>` and `<style>` elements
- Add request timeout and HTTP error handling
- Add a polite `User-Agent` for remote requests
- Preserve the source URL in record metadata
- Add tests for successful extraction, HTTP errors, and empty pages
- Add `beautifulsoup4` and `requests` to the `ingest` dependencies

## Testing

- `uv run ruff check src/dynavec/ingest.py`
- `uv run pytest`

## Related issue

Closes #59