### PR TITLE
add graph_export to Mermaid and Graphviz DOT

### DIFF
--- a/examples/graph_export.py
+++ b/examples/graph_export.py
@@ -1,0 +1,61 @@
+"""Export a dynavec knowledge-graph namespace as Mermaid / Graphviz DOT.
+
+Builds a tiny supply-chain graph that deliberately contains a cycle
+(acme -> globex -> initech -> acme), then prints the same subgraph in both
+formats. ``graph_export`` returns a string, so paste the Mermaid block straight
+into a README or pipe the DOT at ``dot -Tsvg``.
+
+Runs against YOUR AWS account — dynavec auto-provisions the DynamoDB table that
+backs the graph on first use. No embedder and no vector search involved.
+
+Run
+---
+    python examples/graph_export.py
+
+Requires AWS credentials with dynamodb + s3vectors permissions.
+"""
+
+from __future__ import annotations
+
+import os
+
+from dynavec import Dynavec, DynavecConfig
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+NAMESPACE = "supply-chain"
+
+cfg = DynavecConfig(
+    vector_bucket="dynavec-demo",
+    index="graph-export",
+    table="dynavec_graph_export",
+    dimension=8,  # unused here: this example never embeds anything
+    region=REGION,
+    auto_provision=True,
+)
+
+db = Dynavec(cfg)
+
+# (src, relation, dst) — the first three edges form a cycle.
+EDGES = [
+    ("acme", "competes_with", "globex"),
+    ("globex", "supplies", "initech"),
+    ("initech", "supplies", "acme"),
+    ("acme", "owns", "Acme Logistics GmbH"),  # spaces: needs escaping
+    ("globex", "spun off", "end-of-life unit"),  # reserved word + hyphen
+]
+
+for src, relation, dst in EDGES:
+    db.graph_add_edge(src, relation, dst, namespace=NAMESPACE)
+
+print("--- mermaid ---")
+print(db.graph.graph_export("mermaid", NAMESPACE))
+
+print("--- graphviz dot ---")
+print(db.graph.graph_export("dot", NAMESPACE))
+
+# Narrow the walk instead of exporting the whole namespace: start at one entity
+# and follow a single relation. (Seeding at "globex" alone would still reach
+# everything here — the acme/globex/initech cycle makes the graph strongly
+# connected, and the walk terminates on it either way.)
+print("--- mermaid, 'supplies' chain from globex ---")
+print(db.graph.graph_export("mermaid", NAMESPACE, roots=["globex"], relation="supplies"))

--- a/src/dynavec/graph.py
+++ b/src/dynavec/graph.py
@@ -23,12 +23,124 @@ fan-out entities want a sort-key adjacency design (roadmap).
 
 from __future__ import annotations
 
+import re
+from collections import deque
 from typing import Any
 
 from .config import DynavecConfig
-from .utils import KEY_SEPARATOR, encode_key_component, retry
+from .utils import KEY_SEPARATOR, decode_key_component, encode_key_component, retry
 
 Props = dict[str, Any]
+
+EXPORT_FORMATS = ("mermaid", "dot")
+
+# A bare Mermaid flowchart node id: letters/digits/underscore, not keyword-shaped.
+_MERMAID_SAFE_ID = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
+# An unquoted Mermaid edge label may not carry the `|` delimiter or spaces.
+_MERMAID_SAFE_LABEL = re.compile(r"^[A-Za-z0-9_]+$")
+# Flowchart keywords. Used bare they are parsed as syntax, not as a node.
+_MERMAID_RESERVED = frozenset(
+    {
+        "call",
+        "class",
+        "classdef",
+        "click",
+        "direction",
+        "end",
+        "flowchart",
+        "graph",
+        "href",
+        "linkstyle",
+        "style",
+        "subgraph",
+    }
+)
+
+
+def _mermaid_text(value: str) -> str:
+    """Escape a Mermaid label. Mermaid uses `#nnn;` entities, not backslashes."""
+    return (
+        value.replace("#", "#35;")  # first: later replacements introduce `#`
+        .replace('"', "#quot;")
+        .replace("<", "#lt;")
+        .replace(">", "#gt;")
+    )
+
+
+def _mermaid_label(relation: str) -> str:
+    """Render an edge label, quoting it only when it cannot stand bare."""
+    if _MERMAID_SAFE_LABEL.match(relation):
+        return relation
+    return f'"{_mermaid_text(relation)}"'
+
+
+def _mermaid_aliases(nodes: list[str]) -> dict[str, str]:
+    """Map entity id -> Mermaid node id.
+
+    Ids that are already valid Mermaid identifiers are used verbatim, so the
+    common case stays readable. Anything else (spaces, quotes, hyphens, a
+    reserved keyword) gets an `nN` alias carrying the real id as its label.
+    Alias numbering follows sorted id order, so it is stable across exports.
+    """
+    bare = {
+        n for n in nodes if _MERMAID_SAFE_ID.match(n) and n.lower() not in _MERMAID_RESERVED
+    }
+    aliases: dict[str, str] = {}
+    counter = 0
+    for node in nodes:
+        if node in bare:
+            aliases[node] = node
+            continue
+        candidate = f"n{counter}"
+        while candidate in bare:  # never shadow a real id spelled `n0`
+            counter += 1
+            candidate = f"n{counter}"
+        aliases[node] = candidate
+        counter += 1
+    return aliases
+
+
+def _render_mermaid(nodes: list[str], edges: list[tuple[str, str, str]]) -> str:
+    aliases = _mermaid_aliases(nodes)
+    linked = {n for src, _, dst in edges for n in (src, dst)}
+    lines = ["graph LR"]
+    for node in nodes:
+        alias = aliases[node]
+        if alias != node:
+            lines.append(f'  {alias}["{_mermaid_text(node)}"]')
+        elif node not in linked:
+            lines.append(f"  {node}")  # isolated: declare it or it vanishes
+    for src, relation, dst in edges:
+        arrow = f"-->|{_mermaid_label(relation)}|" if relation else "-->"
+        lines.append(f"  {aliases[src]} {arrow} {aliases[dst]}")
+    return "\n".join(lines) + "\n"
+
+
+def _dot_text(value: str) -> str:
+    """Escape a DOT quoted string. Every id is quoted, so this is all it takes."""
+    return (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+
+
+def _render_dot(nodes: list[str], edges: list[tuple[str, str, str]]) -> str:
+    linked = {n for src, _, dst in edges for n in (src, dst)}
+    lines = ["digraph G {"]
+    for node in nodes:
+        if node not in linked:
+            lines.append(f'  "{_dot_text(node)}";')
+    for src, relation, dst in edges:
+        attrs = f' [label="{_dot_text(relation)}"]' if relation else ""
+        lines.append(f'  "{_dot_text(src)}" -> "{_dot_text(dst)}"{attrs};')
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+_RENDERERS = {"mermaid": _render_mermaid, "dot": _render_dot}
 
 
 class GraphStore:
@@ -125,3 +237,103 @@ class GraphStore:
                     seen.add(doc_id)
                     ordered.append(doc_id)
         return ordered
+
+    @retry()
+    def list_node_ids(self, ns: str) -> list[str]:
+        """Every entity id stored under ``ns``, sorted.
+
+        The namespace lives in the node key, so — exactly like
+        :meth:`~dynavec.client.Dynavec.list_vectors`, which scopes on the
+        decoded vector key because ``ListVectors`` takes no server-side
+        ``filter`` — the scope here is a prefix match on ``pk`` rather than a
+        query on the ``_dv_ns`` tag. ``encode_key_component`` makes the prefix
+        unambiguous: a namespace can never be a prefix of another one's key.
+
+        This is a table scan. Fine for the export/debugging graphs this exists
+        for; not something to put on a hot path.
+        """
+        prefix = f"{encode_key_component(ns)}{KEY_SEPARATOR}node{KEY_SEPARATOR}"
+        params: dict[str, Any] = {
+            "FilterExpression": "begins_with(pk, :prefix)",
+            "ExpressionAttributeValues": {":prefix": prefix},
+            "ProjectionExpression": "pk, entity_id",
+        }
+        ids: list[str] = []
+        while True:
+            resp = self._table.scan(**params)
+            for item in resp.get("Items", []):
+                entity_id = item.get("entity_id")
+                if entity_id is None:  # pre-``entity_id`` item: recover from the key
+                    entity_id = decode_key_component(item["pk"][len(prefix) :])
+                ids.append(entity_id)
+            start_key = resp.get("LastEvaluatedKey")
+            if not start_key:
+                return sorted(ids)
+            params["ExclusiveStartKey"] = start_key
+
+    # ----------------------------------------------------------------- export
+    def graph_export(
+        self,
+        fmt: str,
+        ns: str,
+        *,
+        roots: list[str] | None = None,
+        relation: str | None = None,
+    ) -> str:
+        """Render the ``ns`` subgraph as Mermaid or Graphviz DOT source.
+
+        Returns the diagram as a string — nothing is written or printed, so the
+        caller decides whether it lands in a docs page, a log line, or a file.
+        No new dependency: the text is emitted directly.
+
+        Parameters
+        ----------
+        fmt:
+            ``"mermaid"`` or ``"dot"``. Anything else raises ``ValueError``.
+        ns:
+            Namespace to export. Only this subgraph is walked, never the whole
+            table.
+        roots:
+            Start the walk at these entities and follow edges outwards. The
+            default (``None``) seeds from every node in the namespace, which is
+            the whole subgraph including nodes nothing points at.
+        relation:
+            Only traverse and emit edges carrying this relation.
+
+        Output is deterministic: nodes and edges are sorted, and each edge is
+        emitted exactly once even when the graph contains cycles.
+        """
+        render = _RENDERERS.get(fmt)
+        if render is None:
+            supported = ", ".join(repr(f) for f in EXPORT_FORMATS)
+            raise ValueError(f"Unknown export format {fmt!r}. Supported formats: {supported}.")
+        nodes, edges = self._collect_subgraph(ns, roots, relation)
+        return render(nodes, edges)
+
+    def _collect_subgraph(
+        self, ns: str, roots: list[str] | None, relation: str | None
+    ) -> tuple[list[str], list[tuple[str, str, str]]]:
+        """Breadth-first walk returning ``(sorted nodes, sorted unique edges)``.
+
+        ``visited`` is what makes a cyclic graph terminate; ``edges`` is a set,
+        so a duplicated adjacency entry still renders one arrow.
+        """
+        seeds = self.list_node_ids(ns) if roots is None else list(dict.fromkeys(roots))
+        visited: set[str] = set(seeds)
+        edges: set[tuple[str, str, str]] = set()
+        queue = deque(seeds)
+        while queue:
+            entity_id = queue.popleft()
+            node = self.get_node(ns, entity_id)
+            if not node:
+                continue
+            for edge in node.get("edges", []):
+                edge_relation = edge.get("relation") or ""
+                if relation is not None and edge_relation != relation:
+                    continue
+                target = edge["target"]
+                edges.add((entity_id, edge_relation, target))
+                if target not in visited:
+                    visited.add(target)
+                    queue.append(target)
+        return sorted(visited), sorted(edges)

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -1,0 +1,277 @@
+"""Mermaid / Graphviz export of a namespace subgraph.
+
+Same convention as the other graph tests: subclass the real ``GraphStore`` and
+swap the DynamoDB calls for a dict, so the traversal and the renderers under
+test are the real ones.
+"""
+
+import boto3
+import pytest
+from botocore.stub import Stubber
+
+from dynavec.config import DynavecConfig
+from dynavec.graph import GraphStore
+
+
+class FakeGraph(GraphStore):
+    """In-memory stand-in: only the two DynamoDB reads are replaced."""
+
+    def __init__(self):
+        self._nodes = {}  # (ns, entity_id) -> {"edges": [...], "docs": [...]}
+
+    def _node(self, ns, entity_id):
+        return self._nodes.setdefault((ns, entity_id), {"edges": [], "docs": []})
+
+    def add_node(self, ns, entity_id, ntype=None, props=None):
+        self._node(ns, entity_id)
+
+    def add_edge(self, ns, src, relation, dst):
+        self._node(ns, src)["edges"].append({"relation": relation, "target": dst})
+        self._node(ns, dst)
+
+    def get_node(self, ns, entity_id):
+        return self._nodes.get((ns, entity_id))
+
+    def list_node_ids(self, ns):
+        return sorted(eid for node_ns, eid in self._nodes if node_ns == ns)
+
+
+@pytest.fixture
+def graph():
+    g = FakeGraph()
+    g.add_edge("corp", "acme", "competes_with", "globex")
+    g.add_edge("corp", "globex", "supplies", "initech")
+    # a second namespace that must never leak into a "corp" export
+    g.add_edge("other", "hooli", "acquires", "piedpiper")
+    return g
+
+
+def test_mermaid_export_renders_the_namespace_subgraph(graph):
+    assert graph.graph_export("mermaid", "corp") == (
+        "graph LR\n"
+        "  acme -->|competes_with| globex\n"
+        "  globex -->|supplies| initech\n"
+    )
+
+
+def test_dot_export_renders_the_namespace_subgraph(graph):
+    assert graph.graph_export("dot", "corp") == (
+        "digraph G {\n"
+        '  "acme" -> "globex" [label="competes_with"];\n'
+        '  "globex" -> "initech" [label="supplies"];\n'
+        "}\n"
+    )
+
+
+def test_export_is_scoped_to_one_namespace(graph):
+    assert "hooli" not in graph.graph_export("mermaid", "corp")
+    assert "acme" not in graph.graph_export("mermaid", "other")
+
+
+# --------------------------------------------------------------------- cycles
+def test_cycle_terminates_and_emits_each_edge_once():
+    g = FakeGraph()
+    g.add_edge("ns", "a", "next", "b")
+    g.add_edge("ns", "b", "next", "c")
+    g.add_edge("ns", "c", "next", "a")  # closes the loop
+    g.add_edge("ns", "a", "next", "b")  # duplicate adjacency entry
+
+    assert g.graph_export("mermaid", "ns") == (
+        "graph LR\n"
+        "  a -->|next| b\n"
+        "  b -->|next| c\n"
+        "  c -->|next| a\n"
+    )
+
+
+def test_cycle_terminates_when_walking_from_a_root():
+    g = FakeGraph()
+    g.add_edge("ns", "a", "next", "b")
+    g.add_edge("ns", "b", "next", "a")
+    g.add_node("ns", "orphan")  # unreachable from "a", so absent
+
+    assert g.graph_export("mermaid", "ns", roots=["a"]) == (
+        "graph LR\n"
+        "  a -->|next| b\n"
+        "  b -->|next| a\n"
+    )
+
+
+def test_self_loop_terminates():
+    g = FakeGraph()
+    g.add_edge("ns", "a", "cites", "a")
+
+    assert g.graph_export("dot", "ns") == (
+        "digraph G {\n"
+        '  "a" -> "a" [label="cites"];\n'
+        "}\n"
+    )
+
+
+# -------------------------------------------------------------------- escaping
+@pytest.fixture
+def awkward():
+    g = FakeGraph()
+    g.add_edge("ns", "acme corp", "competes with", "end")  # space; reserved word
+    g.add_edge("ns", 'say "hi"', "knows", "acme corp")  # quotes
+    g.add_edge("ns", "#hash", "tag", "multi-word")  # `#` entity; hyphen
+    return g
+
+
+def test_mermaid_escapes_ids_and_labels(awkward):
+    # None of these ids can stand bare in Mermaid, so each gets an `nN` alias
+    # carrying the real id as an escaped label.
+    assert awkward.graph_export("mermaid", "ns") == (
+        "graph LR\n"
+        '  n0["#35;hash"]\n'
+        '  n1["acme corp"]\n'
+        '  n2["end"]\n'
+        '  n3["multi-word"]\n'
+        '  n4["say #quot;hi#quot;"]\n'
+        "  n0 -->|tag| n3\n"
+        '  n1 -->|"competes with"| n2\n'
+        "  n4 -->|knows| n1\n"
+    )
+
+
+def test_dot_escapes_ids_and_labels(awkward):
+    # DOT quotes every id, so only the backslash/quote pair needs escaping.
+    assert awkward.graph_export("dot", "ns") == (
+        "digraph G {\n"
+        '  "#hash" -> "multi-word" [label="tag"];\n'
+        '  "acme corp" -> "end" [label="competes with"];\n'
+        '  "say \\"hi\\"" -> "acme corp" [label="knows"];\n'
+        "}\n"
+    )
+
+
+def test_mermaid_alias_never_shadows_a_real_id():
+    g = FakeGraph()
+    g.add_edge("ns", "n0", "points_at", "zz top")  # "n0" is a legal bare id
+
+    assert g.graph_export("mermaid", "ns") == (
+        "graph LR\n"
+        '  n1["zz top"]\n'
+        "  n0 -->|points_at| n1\n"
+    )
+
+
+def test_dot_escapes_backslashes():
+    g = FakeGraph()
+    g.add_node("ns", "c:\\temp")
+
+    assert g.graph_export("dot", "ns") == 'digraph G {\n  "c:\\\\temp";\n}\n'
+
+
+# ------------------------------------------------------------- degenerate input
+def test_unknown_format_raises_value_error(graph):
+    with pytest.raises(ValueError) as excinfo:
+        graph.graph_export("graphml", "corp")
+
+    message = str(excinfo.value)
+    assert "'mermaid'" in message and "'dot'" in message
+
+
+def test_empty_subgraph_returns_an_empty_document(graph):
+    assert graph.graph_export("mermaid", "nothing-here") == "graph LR\n"
+    assert graph.graph_export("dot", "nothing-here") == "digraph G {\n}\n"
+
+
+def test_isolated_nodes_are_declared():
+    g = FakeGraph()
+    g.add_node("ns", "lonely")
+    g.add_edge("ns", "a", "next", "b")
+
+    assert g.graph_export("mermaid", "ns") == (
+        "graph LR\n"
+        "  lonely\n"
+        "  a -->|next| b\n"
+    )
+    assert g.graph_export("dot", "ns") == (
+        "digraph G {\n"
+        '  "lonely";\n'
+        '  "a" -> "b" [label="next"];\n'
+        "}\n"
+    )
+
+
+def test_relation_filter_keeps_only_matching_edges():
+    g = FakeGraph()
+    g.add_edge("ns", "a", "next", "b")
+    g.add_edge("ns", "a", "owns", "c")
+
+    assert g.graph_export("mermaid", "ns", roots=["a"], relation="next") == (
+        "graph LR\n"
+        "  a -->|next| b\n"
+    )
+
+
+# ------------------------------------------------------- list_node_ids (stubbed)
+def _stubbed_store():
+    """A real ``GraphStore`` whose DynamoDB calls go through a botocore stub.
+
+    Same trick as ``test_list_vectors.py``: the stub validates our request
+    parameters against the actual DynamoDB service model, which a hand-rolled
+    fake table cannot.
+    """
+    session = boto3.Session(
+        aws_access_key_id="testing", aws_secret_access_key="testing", region_name="us-east-1"
+    )
+    ddb = session.resource("dynamodb", region_name="us-east-1")
+    store = GraphStore.__new__(GraphStore)
+    store._config = DynavecConfig(
+        vector_bucket="test-bucket", index="test-index", table="test-table", dimension=4
+    )
+    store._ddb = ddb
+    store._table = ddb.Table("test-table")
+    return store, Stubber(ddb.meta.client)
+
+
+def test_list_node_ids_scans_the_namespace_prefix_and_paginates():
+    store, stubber = _stubbed_store()
+    base = {
+        "TableName": "test-table",
+        "FilterExpression": "begins_with(pk, :prefix)",
+        # the namespace is escaped into the key, so the prefix is unambiguous
+        "ExpressionAttributeValues": {":prefix": "corp#node#"},
+        "ProjectionExpression": "pk, entity_id",
+    }
+    with stubber as stub:
+        stub.add_response(
+            "scan",
+            {
+                "Items": [
+                    {"pk": {"S": "corp#node#globex"}, "entity_id": {"S": "globex"}},
+                    {"pk": {"S": "corp#node#acme"}, "entity_id": {"S": "acme"}},
+                ],
+                "LastEvaluatedKey": {"pk": {"S": "corp#node#acme"}},
+            },
+            base,
+        )
+        stub.add_response(
+            "scan",
+            # no entity_id attribute: recovered by decoding the key
+            {"Items": [{"pk": {"S": "corp#node#initech%23eu"}}]},
+            {**base, "ExclusiveStartKey": {"pk": "corp#node#acme"}},
+        )
+
+        assert store.list_node_ids("corp") == ["acme", "globex", "initech#eu"]
+        stub.assert_no_pending_responses()
+
+
+def test_list_node_ids_escapes_the_namespace_into_the_prefix():
+    store, stubber = _stubbed_store()
+    with stubber as stub:
+        stub.add_response(
+            "scan",
+            {"Items": []},
+            {
+                "TableName": "test-table",
+                "FilterExpression": "begins_with(pk, :prefix)",
+                "ExpressionAttributeValues": {":prefix": "tenant%23one#node#"},
+                "ProjectionExpression": "pk, entity_id",
+            },
+        )
+
+        assert store.list_node_ids("tenant#one") == []
+        stub.assert_no_pending_responses()


### PR DESCRIPTION
Export a namespace subgraph as diagram source for docs and debugging.

GraphStore.graph_export(fmt, ns) renders "mermaid" or "dot" and returns the text; it never writes or prints, and pulls in no new dependency. An unknown format raises ValueError naming both supported ones.

Scoping follows the existing read path: the namespace is encoded into the node key, so the walk is seeded from a pk-prefix scan (new GraphStore.list_node_ids) rather than a query on the _dv_ns tag — the same reason list_vectors scopes on the decoded vector key.

The breadth-first walk keeps a visited set, so cycles terminate, and collects edges into a set, so a duplicated adjacency entry still renders one arrow. Nodes and edges are sorted before rendering, making the output byte-stable.

Escaping is per-format. DOT quotes every id and escapes \ " and whitespace. Mermaid keeps ids that are already valid identifiers bare, and gives anything else (spaces, quotes, hyphens, reserved words like `end`) an nN alias carrying the real id as a #nnn;-escaped label, never shadowing a real id.

closes #33 




