### PR TITLE
feat: add async LangChain retrieval for #70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install (with dev extras)
-        run: uv pip install -e ".[dev,ingest]"
+        run: uv pip install -e ".[dev,ingest,langchain]"
       - name: Lint
         run: uv run --no-sync ruff check src benchmarks
       - name: Test

--- a/src/dynavec/integrations/langchain.py
+++ b/src/dynavec/integrations/langchain.py
@@ -12,6 +12,7 @@ is wrapped to satisfy dynavec's :class:`~dynavec.embeddings.base.Embedder`).
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from collections.abc import Iterable
 from typing import Any
@@ -87,6 +88,28 @@ class DynavecVectorStore(VectorStore):
             for r in results
         ]
 
+    async def asimilarity_search(
+        self,
+        query: str,
+        k: int = 4,
+        filter: dict | None = None,
+        **kwargs: Any,
+    ) -> list[LCDocument]:
+        results = await asyncio.to_thread(
+            self._client.search,
+            query,
+            top_k=k,
+            namespace=self._namespace,
+            filter=filter,
+        )
+        return [
+            LCDocument(
+                page_content=r.text or "",
+                metadata={**r.metadata, "id": r.id, "score": r.score},
+            )
+            for r in results
+        ]
+
     def similarity_search_with_score(
         self, query: str, k: int = 4, filter: dict | None = None, **kwargs: Any
     ) -> list[tuple[LCDocument, float]]:
@@ -96,6 +119,31 @@ class DynavecVectorStore(VectorStore):
         return [
             (
                 LCDocument(page_content=r.text or "", metadata={**r.metadata, "id": r.id}),
+                r.score,
+            )
+            for r in results
+        ]
+
+    async def asimilarity_search_with_score(
+        self,
+        query: str,
+        k: int = 4,
+        filter: dict | None = None,
+        **kwargs: Any,
+    ) -> list[tuple[LCDocument, float]]:
+        results = await asyncio.to_thread(
+            self._client.search,
+            query,
+            top_k=k,
+            namespace=self._namespace,
+            filter=filter,
+        )
+        return [
+            (
+                LCDocument(
+                    page_content=r.text or "",
+                    metadata={**r.metadata, "id": r.id},
+                ),
                 r.score,
             )
             for r in results
@@ -120,6 +168,32 @@ class DynavecVectorStore(VectorStore):
         )
         return [
             LCDocument(page_content=r.text or "", metadata={**r.metadata, "id": r.id, "score": r.score})
+            for r in results
+        ]
+
+    async def amax_marginal_relevance_search(
+        self,
+        query: str,
+        k: int = 4,
+        fetch_k: int = 20,
+        lambda_mult: float = 0.5,
+        filter: dict | None = None,
+        **kwargs: Any,
+    ) -> list[LCDocument]:
+        results = await asyncio.to_thread(
+            self._client.search,
+            query,
+            top_k=k,
+            namespace=self._namespace,
+            filter=filter,
+            rerank="mmr",
+            mmr_lambda=lambda_mult,
+        )
+        return [
+            LCDocument(
+                page_content=r.text or "",
+                metadata={**r.metadata, "id": r.id, "score": r.score},
+            )
             for r in results
         ]
 

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -1,0 +1,125 @@
+"""Tests for the LangChain vector store integration."""
+
+from dynavec.integrations.langchain import DynavecVectorStore
+from dynavec.models import SearchResult
+
+
+class _FakeClient:
+    embedder = None
+
+    def __init__(self):
+        self.calls = []
+
+    def search(self, query, **kwargs):
+        self.calls.append((query, kwargs))
+        return [
+            SearchResult(
+                id="doc-1",
+                score=0.95,
+                text="Async Dynavec result",
+                metadata={"topic": "ai"},
+            )
+        ]
+
+
+def _fail_sync(*args, **kwargs):
+    raise AssertionError("sync fallback should not be used")
+
+
+async def test_async_retriever_ainvoke(monkeypatch):
+    client = _FakeClient()
+    store = DynavecVectorStore(client, namespace="kb")
+
+    monkeypatch.setattr(store, "similarity_search", _fail_sync)
+
+    retriever = store.as_retriever(search_kwargs={"k": 4})
+    docs = await retriever.ainvoke("machine learning")
+
+    assert len(docs) == 1
+    assert docs[0].page_content == "Async Dynavec result"
+    assert docs[0].metadata == {
+        "topic": "ai",
+        "id": "doc-1",
+        "score": 0.95,
+    }
+
+    assert client.calls == [
+        (
+            "machine learning",
+            {
+                "top_k": 4,
+                "namespace": "kb",
+                "filter": None,
+            },
+        )
+    ]
+
+
+async def test_async_similarity_search_with_score(monkeypatch):
+    client = _FakeClient()
+    store = DynavecVectorStore(client, namespace="kb")
+
+    monkeypatch.setattr(store, "similarity_search_with_score", _fail_sync)
+
+    results = await store.asimilarity_search_with_score(
+        "machine learning",
+        k=2,
+        filter={"topic": "ai"},
+    )
+
+    assert len(results) == 1
+
+    document, score = results[0]
+
+    assert document.page_content == "Async Dynavec result"
+    assert document.metadata == {
+        "topic": "ai",
+        "id": "doc-1",
+    }
+    assert score == 0.95
+
+    assert client.calls == [
+        (
+            "machine learning",
+            {
+                "top_k": 2,
+                "namespace": "kb",
+                "filter": {"topic": "ai"},
+            },
+        )
+    ]
+
+
+async def test_async_max_marginal_relevance_search(monkeypatch):
+    client = _FakeClient()
+    store = DynavecVectorStore(client, namespace="kb")
+
+    monkeypatch.setattr(store, "max_marginal_relevance_search", _fail_sync)
+
+    docs = await store.amax_marginal_relevance_search(
+        "machine learning",
+        k=3,
+        lambda_mult=0.7,
+        filter={"topic": "ai"},
+    )
+
+    assert len(docs) == 1
+    assert docs[0].page_content == "Async Dynavec result"
+    assert docs[0].metadata == {
+        "topic": "ai",
+        "id": "doc-1",
+        "score": 0.95,
+    }
+
+    assert client.calls == [
+        (
+            "machine learning",
+            {
+                "top_k": 3,
+                "namespace": "kb",
+                "filter": {"topic": "ai"},
+                "rerank": "mmr",
+                "mmr_lambda": 0.7,
+            },
+        )
+    ]


### PR DESCRIPTION
## Description

Adds first-class async retrieval support to the LangChain `DynavecVectorStore`.

The async vector-store methods delegate Dynavec's synchronous search through `asyncio.to_thread()`, keeping the event loop unblocked while using the current synchronous Dynavec client.

## Related issue

Fixes #70

## Changes

- Added `asimilarity_search()` and `asimilarity_search_with_score()`.
- Added `amax_marginal_relevance_search()` with the existing MMR behavior.
- Added tests through the LangChain retriever `ainvoke()` path, plus score and MMR coverage.
- Updated CI to install the existing `langchain` optional extra so the LangChain tests run in a clean CI environment.

## Testing

- [x] Tests pass locally (`323 passed, 2 skipped`)
- [x] Ruff checks pass
- [x] Documentation updated, if applicable

## Checklist

- [x] My changes are focused and relevant to this pull request.
- [x] I have added or updated tests where appropriate.
- [x] I have reviewed my changes for unrelated modifications.
- [x] I have updated documentation where necessary.
