### PR TITLE
feat(eval): add retrieval quality runner for recall@k, MRR, and nDCG (#134)

### DIFF
--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -36,6 +36,9 @@ export interface TraceEvent {
   query_preview: string | null;
   eval_faithfulness?: number | null;
   eval_relevance?: number | null;
+  eval_recall?: number | null;
+  eval_mrr?: number | null;
+  eval_ndcg?: number | null;
 }
 
 export interface TraceFilters {

--- a/src/dynavec/dashboard.py
+++ b/src/dynavec/dashboard.py
@@ -251,7 +251,11 @@ def _make_handler(recorder: TelemetryRecorder):
                 eval_runs = [
                     e.to_dict()
                     for e in all_events
-                    if e.eval_faithfulness is not None or e.eval_relevance is not None
+                    if e.eval_faithfulness is not None
+                    or e.eval_relevance is not None
+                    or e.eval_recall is not None
+                    or e.eval_mrr is not None
+                    or e.eval_ndcg is not None
                 ][:limit]
                 return self._send(200, json.dumps(eval_runs))
             return self._send(404, json.dumps({"error": "not found"}))

--- a/src/dynavec/eval/__init__.py
+++ b/src/dynavec/eval/__init__.py
@@ -1,4 +1,4 @@
-"""LLM-as-a-Judge evaluation framework for RAG faithfulness and answer relevance."""
+"""Evaluation framework for RAG faithfulness, answer relevance, and retrieval quality (Recall/MRR/nDCG)."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ from .base import (
     RAGEvalResult,
     extract_json,
 )
-from .chart import plot_eval_summary
+from .chart import plot_eval_summary, plot_retrieval_metrics
 from .judges import (
     BedrockJudge,
     CustomJudge,
@@ -23,12 +23,23 @@ from .metrics import (
     evaluate_faithfulness,
     evaluate_rag,
 )
+from .retrieval import (
+    LabeledQuery,
+    RetrievalEvalRunner,
+    RetrievalEvalSummary,
+    RetrievalMetricResult,
+    compute_mrr,
+    compute_ndcg_at_k,
+    compute_precision_at_k,
+    compute_recall_at_k,
+)
 from .runner import (
     EvalRunner,
     EvalSummary,
 )
 
 __all__ = [
+    # LLM Judge & Data Models
     "BaseJudge",
     "OpenAIJudge",
     "BedrockJudge",
@@ -46,4 +57,14 @@ __all__ = [
     "EvalRunner",
     "EvalSummary",
     "plot_eval_summary",
+    # Information Retrieval (IR) Evaluation
+    "LabeledQuery",
+    "RetrievalMetricResult",
+    "RetrievalEvalSummary",
+    "RetrievalEvalRunner",
+    "compute_recall_at_k",
+    "compute_mrr",
+    "compute_ndcg_at_k",
+    "compute_precision_at_k",
+    "plot_retrieval_metrics",
 ]

--- a/src/dynavec/eval/chart.py
+++ b/src/dynavec/eval/chart.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .runner import EvalSummary
@@ -31,23 +31,21 @@ def plot_eval_summary(
     """
     try:
         import matplotlib
+
         matplotlib.use("Agg")  # headless mode
         import matplotlib.pyplot as plt
     except ImportError as exc:
         from ..exceptions import MissingDependencyError
+
         raise MissingDependencyError("plot_eval_summary", "matplotlib", "benchmark") from exc
 
     results = summary.results
     if not results:
         raise ValueError("Cannot plot empty evaluation results.")
 
-    faith_scores = [
-        r.faithfulness.score if r.faithfulness is not None else 0.0
-        for r in results
-    ]
+    faith_scores = [r.faithfulness.score if r.faithfulness is not None else 0.0 for r in results]
     rel_scores = [
-        r.answer_relevance.score if r.answer_relevance is not None else 0.0
-        for r in results
+        r.answer_relevance.score if r.answer_relevance is not None else 0.0 for r in results
     ]
 
     fig, ax = plt.subplots(figsize=(8, 6), dpi=150)
@@ -69,7 +67,9 @@ def plot_eval_summary(
 
     # Reference lines for pass threshold
     threshold = summary.pass_threshold
-    ax.axvline(threshold, color="#6F6862", linestyle="--", alpha=0.5, label=f"Pass Threshold ({threshold})")
+    ax.axvline(
+        threshold, color="#6F6862", linestyle="--", alpha=0.5, label=f"Pass Threshold ({threshold})"
+    )
     ax.axhline(threshold, color="#6F6862", linestyle="--", alpha=0.5)
 
     # Mean score crosshairs
@@ -85,8 +85,12 @@ def plot_eval_summary(
 
     ax.set_xlim(-0.05, 1.05)
     ax.set_ylim(-0.05, 1.05)
-    ax.set_xlabel("Faithfulness (Groundedness in Context)", fontsize=11, fontweight="bold", color="#14110F")
-    ax.set_ylabel("Answer Relevance (Intent Alignment)", fontsize=11, fontweight="bold", color="#14110F")
+    ax.set_xlabel(
+        "Faithfulness (Groundedness in Context)", fontsize=11, fontweight="bold", color="#14110F"
+    )
+    ax.set_ylabel(
+        "Answer Relevance (Intent Alignment)", fontsize=11, fontweight="bold", color="#14110F"
+    )
     ax.set_title(title, fontsize=13, fontweight="bold", pad=12, color="#14110F")
 
     # Styling
@@ -105,6 +109,122 @@ def plot_eval_summary(
     plt.figtext(0.5, 0.02, stats_text, ha="center", fontsize=9, color="#6F6862", family="monospace")
 
     plt.tight_layout(rect=(0, 0.04, 1, 1))
+    plt.savefig(output_path, bbox_inches="tight")
+    plt.close(fig)
+
+    return output_path
+
+
+def plot_retrieval_metrics(
+    summary: Any,
+    output_path: str = "retrieval_eval.png",
+    title: str = "Retrieval Quality Evaluation (Recall / MRR / nDCG)",
+) -> str:
+    """Generate visual curves and summary charts for retrieval evaluation results.
+
+    Parameters
+    ----------
+    summary:
+        RetrievalEvalSummary object from RetrievalEvalRunner.
+    output_path:
+        File path to save the generated PNG chart.
+    title:
+        Chart title.
+
+    Returns
+    -------
+    str:
+        The output path where the chart was saved.
+    """
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")  # headless mode
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        from ..exceptions import MissingDependencyError
+
+        raise MissingDependencyError("plot_retrieval_metrics", "matplotlib", "benchmark") from exc
+
+    if not hasattr(summary, "k_values") or not summary.k_values:
+        raise ValueError("Cannot plot empty retrieval evaluation summary.")
+
+    k_vals = summary.k_values
+    recalls = [summary.mean_recall.get(k, 0.0) for k in k_vals]
+    ndcgs = [summary.mean_ndcg.get(k, 0.0) for k in k_vals]
+    precisions = [summary.mean_precision.get(k, 0.0) for k in k_vals]
+
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5), dpi=150)
+    fig.patch.set_facecolor("#FBFAF8")
+    ax1.set_facecolor("#FFFFFF")
+    ax2.set_facecolor("#FFFFFF")
+
+    # Panel 1: Recall@k & nDCG@k vs k
+    ax1.plot(k_vals, recalls, marker="o", color="#E8623B", linewidth=2.2, label="Recall@k")
+    ax1.plot(k_vals, ndcgs, marker="s", color="#2F7D5B", linewidth=2.2, label="nDCG@k")
+    ax1.plot(
+        k_vals,
+        precisions,
+        marker="^",
+        color="#4C78A8",
+        linewidth=1.8,
+        linestyle="--",
+        label="Precision@k",
+    )
+
+    ax1.set_xlabel("Rank Cutoff (k)", fontsize=11, fontweight="bold", color="#14110F")
+    ax1.set_ylabel("Score (0.0 – 1.0)", fontsize=11, fontweight="bold", color="#14110F")
+    ax1.set_title("Ranking Quality vs Cutoff (k)", fontsize=12, fontweight="bold", color="#14110F")
+    ax1.set_ylim(-0.05, 1.05)
+    ax1.set_xticks(k_vals)
+    ax1.grid(True, linestyle=":", alpha=0.6, color="#ECE6DF")
+    ax1.legend(loc="lower right", framealpha=0.9, facecolor="#FBFAF8", edgecolor="#ECE6DF")
+
+    # Panel 2: Summary Metrics Bar Chart
+    max_k = k_vals[-1]
+    metrics_labels = ["MRR", f"Recall@{max_k}", f"nDCG@{max_k}", f"Precision@{max_k}"]
+    metrics_vals = [
+        summary.mean_mrr,
+        summary.mean_recall.get(max_k, 0.0),
+        summary.mean_ndcg.get(max_k, 0.0),
+        summary.mean_precision.get(max_k, 0.0),
+    ]
+    colors = ["#F58518", "#E8623B", "#2F7D5B", "#4C78A8"]
+
+    bars = ax2.bar(
+        metrics_labels, metrics_vals, color=colors, width=0.55, edgecolor="#14110F", linewidth=0.8
+    )
+    for bar in bars:
+        h = bar.get_height()
+        ax2.text(
+            bar.get_x() + bar.get_width() / 2.0,
+            h + 0.02,
+            f"{h:.3f}",
+            ha="center",
+            va="bottom",
+            fontsize=10,
+            fontweight="bold",
+        )
+
+    ax2.set_ylim(0, 1.15)
+    ax2.set_ylabel("Mean Score", fontsize=11, fontweight="bold", color="#14110F")
+    ax2.set_title("Aggregate Metric Summary", fontsize=12, fontweight="bold", color="#14110F")
+    ax2.grid(True, axis="y", linestyle=":", alpha=0.6, color="#ECE6DF")
+
+    for ax in (ax1, ax2):
+        for spine in ax.spines.values():
+            spine.set_color("#ECE6DF")
+
+    fig.suptitle(title, fontsize=13, fontweight="bold", y=0.98, color="#14110F")
+
+    stats_text = (
+        f"Total Queries: {summary.total_queries}  |  "
+        f"p50 Latency: {summary.p50_latency_ms:.1f}ms  |  "
+        f"p95 Latency: {summary.p95_latency_ms:.1f}ms"
+    )
+    plt.figtext(0.5, 0.02, stats_text, ha="center", fontsize=9, color="#6F6862", family="monospace")
+
+    plt.tight_layout(rect=(0, 0.04, 1, 0.95))
     plt.savefig(output_path, bbox_inches="tight")
     plt.close(fig)
 

--- a/src/dynavec/eval/retrieval.py
+++ b/src/dynavec/eval/retrieval.py
@@ -1,0 +1,422 @@
+"""Information Retrieval (IR) quality evaluation runner (Recall@k, MRR, nDCG@k, Precision@k)."""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from collections.abc import Mapping, Sequence, Set
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class LabeledQuery:
+    """A ground-truth labeled evaluation query."""
+
+    query: str
+    relevant_ids: set[str] | list[str]
+    query_id: str = ""
+    relevance_grades: dict[str, float] | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.query_id:
+            self.query_id = f"q_{abs(hash(self.query)) % 1_000_000:06d}"
+        if isinstance(self.relevant_ids, list):
+            self.relevant_ids = set(self.relevant_ids)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "query_id": self.query_id,
+            "query": self.query,
+            "relevant_ids": sorted(self.relevant_ids),
+            "relevance_grades": self.relevance_grades,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass
+class RetrievalMetricResult:
+    """Per-query retrieval metric results across multiple k cutoffs."""
+
+    query_id: str
+    query: str
+    retrieved_ids: list[str]
+    recall_at_k: dict[int, float]
+    mrr: float
+    ndcg_at_k: dict[int, float]
+    precision_at_k: dict[int, float]
+    latency_ms: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "query_id": self.query_id,
+            "query": self.query,
+            "retrieved_ids": self.retrieved_ids,
+            "recall_at_k": self.recall_at_k,
+            "mrr": self.mrr,
+            "ndcg_at_k": self.ndcg_at_k,
+            "precision_at_k": self.precision_at_k,
+            "latency_ms": self.latency_ms,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass
+class RetrievalEvalSummary:
+    """Dataset-level aggregated summary of retrieval quality metrics."""
+
+    total_queries: int
+    k_values: list[int]
+    mean_recall: dict[int, float]
+    mean_mrr: float
+    mean_ndcg: dict[int, float]
+    mean_precision: dict[int, float]
+    p50_latency_ms: float
+    p95_latency_ms: float
+    results: list[RetrievalMetricResult] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "total_queries": self.total_queries,
+            "k_values": self.k_values,
+            "mean_recall": self.mean_recall,
+            "mean_mrr": self.mean_mrr,
+            "mean_ndcg": self.mean_ndcg,
+            "mean_precision": self.mean_precision,
+            "p50_latency_ms": self.p50_latency_ms,
+            "p95_latency_ms": self.p95_latency_ms,
+            "results": [r.to_dict() for r in self.results],
+        }
+
+    def save_json(self, file_path: str | Path) -> None:
+        """Save the summary results as formatted JSON."""
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(self.to_dict(), f, indent=2)
+
+
+# ===========================================================================
+# Mathematical IR Metric Algorithms (Pure Math, Zero Dependencies)
+# ===========================================================================
+
+
+def compute_recall_at_k(
+    retrieved_ids: Sequence[str],
+    relevant_ids: Set[str] | Sequence[str],
+    k: int,
+) -> float:
+    """Compute Recall@k: fraction of all relevant documents retrieved in top-k.
+
+    Recall@k = |Retrieved_k ∩ Relevant| / |Relevant|
+    """
+    rel_set = set(relevant_ids)
+    if not rel_set or k <= 0:
+        return 0.0
+
+    top_k = retrieved_ids[:k]
+    hits = sum(1 for doc_id in top_k if doc_id in rel_set)
+    return round(hits / len(rel_set), 4)
+
+
+def compute_mrr(
+    retrieved_ids: Sequence[str],
+    relevant_ids: Set[str] | Sequence[str],
+    k: int | None = None,
+) -> float:
+    """Compute Mean Reciprocal Rank (MRR): 1 / rank of the first relevant document.
+
+    If no relevant document is retrieved within top-k, returns 0.0.
+    """
+    rel_set = set(relevant_ids)
+    if not rel_set:
+        return 0.0
+
+    candidates = retrieved_ids[:k] if k is not None and k > 0 else retrieved_ids
+    for rank, doc_id in enumerate(candidates, start=1):
+        if doc_id in rel_set:
+            return round(1.0 / rank, 4)
+    return 0.0
+
+
+def compute_ndcg_at_k(
+    retrieved_ids: Sequence[str],
+    relevant_grades_or_ids: Mapping[str, float] | Set[str] | Sequence[str],
+    k: int,
+) -> float:
+    """Compute Normalized Discounted Cumulative Gain (nDCG@k).
+
+    Supports binary relevance (sets/lists) or graded relevance (dict of doc_id -> grade).
+    nDCG@k = DCG@k / IDCG@k
+    where DCG@k = sum_{i=1}^k (2^rel_i - 1) / log2(i + 1)
+    """
+    if k <= 0:
+        return 0.0
+
+    if isinstance(relevant_grades_or_ids, Mapping):
+        grades = {str(doc_id): float(grade) for doc_id, grade in relevant_grades_or_ids.items()}
+    else:
+        grades = {str(doc_id): 1.0 for doc_id in relevant_grades_or_ids}
+
+    if not grades or all(g <= 0.0 for g in grades.values()):
+        return 0.0
+
+    # 1. Compute DCG@k
+    dcg = 0.0
+    cutoff = min(k, len(retrieved_ids))
+    for i in range(cutoff):
+        doc_id = str(retrieved_ids[i])
+        rel = grades.get(doc_id, 0.0)
+        if rel > 0.0:
+            dcg += (math.pow(2.0, rel) - 1.0) / math.log2(i + 2.0)
+
+    # 2. Compute Ideal DCG (IDCG@k)
+    sorted_grades = sorted(grades.values(), reverse=True)[:k]
+    idcg = 0.0
+    for i, rel in enumerate(sorted_grades):
+        if rel > 0.0:
+            idcg += (math.pow(2.0, rel) - 1.0) / math.log2(i + 2.0)
+
+    if idcg <= 0.0:
+        return 0.0
+
+    return round(min(1.0, dcg / idcg), 4)
+
+
+def compute_precision_at_k(
+    retrieved_ids: Sequence[str],
+    relevant_ids: Set[str] | Sequence[str],
+    k: int,
+) -> float:
+    """Compute Precision@k: fraction of top-k retrieved documents that are relevant.
+
+    Precision@k = |Retrieved_k ∩ Relevant| / k
+    """
+    rel_set = set(relevant_ids)
+    if not rel_set or k <= 0:
+        return 0.0
+
+    top_k = retrieved_ids[:k]
+    hits = sum(1 for doc_id in top_k if doc_id in rel_set)
+    return round(hits / float(k), 4)
+
+
+def _percentile(sorted_vals: list[float], pct: float) -> float:
+    if not sorted_vals:
+        return 0.0
+    k = (len(sorted_vals) - 1) * (pct / 100.0)
+    lo = int(k)
+    hi = min(lo + 1, len(sorted_vals) - 1)
+    frac = k - lo
+    return round(sorted_vals[lo] * (1 - frac) + sorted_vals[hi] * frac, 2)
+
+
+# ===========================================================================
+# Batch Retrieval Evaluation Runner
+# ===========================================================================
+
+
+class RetrievalEvalRunner:
+    """Executes Information Retrieval (IR) evaluation over benchmark datasets.
+
+    Parameters
+    ----------
+    search_backend:
+        Either a Dynavec client instance with ``.search(query, top_k=...)``
+        or any custom callable taking ``(query, top_k)`` and returning a list of
+        document IDs or SearchResult objects.
+    k_values:
+        Sequence of rank cutoffs to evaluate (default: [1, 3, 5, 10]).
+    """
+
+    def __init__(
+        self,
+        search_backend: Any,
+        k_values: Sequence[int] = (1, 3, 5, 10),
+    ) -> None:
+        self.search_backend = search_backend
+        self.k_values = sorted(set(k_values))
+        self.max_k = max(self.k_values) if self.k_values else 10
+
+    def _execute_search(self, query: str, top_k: int, namespace: str | None = None) -> list[str]:
+        """Execute search and extract list of document ID strings."""
+        if hasattr(self.search_backend, "search"):
+            kwargs: dict[str, Any] = {"top_k": top_k}
+            if namespace:
+                kwargs["namespace"] = namespace
+            raw_hits = self.search_backend.search(query, **kwargs)
+        elif callable(self.search_backend):
+            raw_hits = self.search_backend(query, top_k)
+        else:
+            raise TypeError("search_backend must have a search() method or be callable.")
+
+        doc_ids: list[str] = []
+        for hit in raw_hits:
+            if hasattr(hit, "id"):
+                doc_ids.append(str(hit.id))
+            elif isinstance(hit, dict) and "id" in hit:
+                doc_ids.append(str(hit["id"]))
+            elif isinstance(hit, str):
+                doc_ids.append(hit)
+            else:
+                doc_ids.append(str(hit))
+        return doc_ids
+
+    def evaluate_query(
+        self,
+        labeled_query: LabeledQuery | dict[str, Any],
+        namespace: str | None = None,
+    ) -> RetrievalMetricResult:
+        """Evaluate a single labeled query against the search backend."""
+        if isinstance(labeled_query, dict):
+            lq = LabeledQuery(
+                query=labeled_query["query"],
+                relevant_ids=labeled_query["relevant_ids"],
+                query_id=labeled_query.get("query_id", ""),
+                relevance_grades=labeled_query.get("relevance_grades"),
+                metadata=labeled_query.get("metadata", {}),
+            )
+        else:
+            lq = labeled_query
+
+        t0 = time.perf_counter()
+        retrieved_ids = self._execute_search(lq.query, top_k=self.max_k, namespace=namespace)
+        elapsed_ms = (time.perf_counter() - t0) * 1000.0
+
+        rel_target: Any = lq.relevance_grades if lq.relevance_grades else lq.relevant_ids
+
+        recall_map: dict[int, float] = {}
+        ndcg_map: dict[int, float] = {}
+        precision_map: dict[int, float] = {}
+
+        for k in self.k_values:
+            recall_map[k] = compute_recall_at_k(retrieved_ids, lq.relevant_ids, k)
+            ndcg_map[k] = compute_ndcg_at_k(retrieved_ids, rel_target, k)
+            precision_map[k] = compute_precision_at_k(retrieved_ids, lq.relevant_ids, k)
+
+        mrr_score = compute_mrr(retrieved_ids, lq.relevant_ids, k=self.max_k)
+
+        return RetrievalMetricResult(
+            query_id=lq.query_id,
+            query=lq.query,
+            retrieved_ids=retrieved_ids,
+            recall_at_k=recall_map,
+            mrr=mrr_score,
+            ndcg_at_k=ndcg_map,
+            precision_at_k=precision_map,
+            latency_ms=round(elapsed_ms, 2),
+            metadata=lq.metadata,
+        )
+
+    def run(
+        self,
+        dataset: Sequence[LabeledQuery | dict[str, Any]] | str | Path,
+        namespace: str | None = None,
+    ) -> RetrievalEvalSummary:
+        """Run retrieval evaluation over an entire dataset."""
+        loaded_queries = self.load_dataset(dataset) if isinstance(dataset, (str, Path)) else dataset
+
+        results: list[RetrievalMetricResult] = []
+        latencies: list[float] = []
+
+        recall_sums = {k: 0.0 for k in self.k_values}
+        ndcg_sums = {k: 0.0 for k in self.k_values}
+        precision_sums = {k: 0.0 for k in self.k_values}
+        mrr_sum = 0.0
+
+        for item in loaded_queries:
+            metric_res = self.evaluate_query(item, namespace=namespace)
+            results.append(metric_res)
+            latencies.append(metric_res.latency_ms)
+
+            mrr_sum += metric_res.mrr
+            for k in self.k_values:
+                recall_sums[k] += metric_res.recall_at_k.get(k, 0.0)
+                ndcg_sums[k] += metric_res.ndcg_at_k.get(k, 0.0)
+                precision_sums[k] += metric_res.precision_at_k.get(k, 0.0)
+
+        n = len(results)
+        mean_recall = {k: round(recall_sums[k] / n, 4) if n > 0 else 0.0 for k in self.k_values}
+        mean_ndcg = {k: round(ndcg_sums[k] / n, 4) if n > 0 else 0.0 for k in self.k_values}
+        mean_precision = {
+            k: round(precision_sums[k] / n, 4) if n > 0 else 0.0 for k in self.k_values
+        }
+        mean_mrr = round(mrr_sum / n, 4) if n > 0 else 0.0
+
+        sorted_lat = sorted(latencies)
+        p50_lat = _percentile(sorted_lat, 50)
+        p95_lat = _percentile(sorted_lat, 95)
+
+        return RetrievalEvalSummary(
+            total_queries=n,
+            k_values=self.k_values,
+            mean_recall=mean_recall,
+            mean_mrr=mean_mrr,
+            mean_ndcg=mean_ndcg,
+            mean_precision=mean_precision,
+            p50_latency_ms=p50_lat,
+            p95_latency_ms=p95_lat,
+            results=results,
+        )
+
+    @staticmethod
+    def load_dataset(
+        source: str | Path | Sequence[dict[str, Any] | LabeledQuery],
+    ) -> list[LabeledQuery]:
+        """Load benchmark queries from JSON, JSONL, or a Python sequence."""
+        if isinstance(source, (str, Path)):
+            p = Path(source)
+            if not p.exists():
+                raise FileNotFoundError(f"Dataset file not found: {p}")
+
+            text = p.read_text(encoding="utf-8").strip()
+            queries: list[LabeledQuery] = []
+
+            # 1. Try standard JSON array
+            if text.startswith("["):
+                raw_data = json.loads(text)
+                for item in raw_data:
+                    queries.append(
+                        LabeledQuery(
+                            query=item["query"],
+                            relevant_ids=item["relevant_ids"],
+                            query_id=item.get("query_id", ""),
+                            relevance_grades=item.get("relevance_grades"),
+                            metadata=item.get("metadata", {}),
+                        )
+                    )
+                return queries
+
+            # 2. Try JSONL (line-delimited JSON)
+            for line in text.splitlines():
+                clean = line.strip()
+                if clean:
+                    item = json.loads(clean)
+                    queries.append(
+                        LabeledQuery(
+                            query=item["query"],
+                            relevant_ids=item["relevant_ids"],
+                            query_id=item.get("query_id", ""),
+                            relevance_grades=item.get("relevance_grades"),
+                            metadata=item.get("metadata", {}),
+                        )
+                    )
+            return queries
+
+        out: list[LabeledQuery] = []
+        for item in source:
+            if isinstance(item, LabeledQuery):
+                out.append(item)
+            elif isinstance(item, dict):
+                out.append(
+                    LabeledQuery(
+                        query=item["query"],
+                        relevant_ids=item["relevant_ids"],
+                        query_id=item.get("query_id", ""),
+                        relevance_grades=item.get("relevance_grades"),
+                        metadata=item.get("metadata", {}),
+                    )
+                )
+        return out

--- a/src/dynavec/telemetry.py
+++ b/src/dynavec/telemetry.py
@@ -48,6 +48,9 @@ class TelemetryEvent:
     query_preview: str | None = None  # only set when capture_text=True
     eval_faithfulness: float | None = None  # 0.0-1.0 when LLM judge ran
     eval_relevance: float | None = None  # 0.0-1.0 when LLM judge ran
+    eval_recall: float | None = None  # 0.0-1.0 recall@k score
+    eval_mrr: float | None = None  # 0.0-1.0 mean reciprocal rank
+    eval_ndcg: float | None = None  # 0.0-1.0 ndcg@k score
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -148,6 +151,9 @@ def aggregate(
 
     faith_scores = [e.eval_faithfulness for e in win if e.eval_faithfulness is not None]
     rel_scores = [e.eval_relevance for e in win if e.eval_relevance is not None]
+    recall_scores = [e.eval_recall for e in win if e.eval_recall is not None]
+    mrr_scores = [e.eval_mrr for e in win if e.eval_mrr is not None]
+    ndcg_scores = [e.eval_ndcg for e in win if e.eval_ndcg is not None]
 
     op_mix: dict[str, int] = {}
     ns_mix: dict[str, int] = {}
@@ -179,7 +185,12 @@ def aggregate(
         if faith_scores
         else None,
         "eval_relevance_mean": round(sum(rel_scores) / len(rel_scores), 4) if rel_scores else None,
-        "eval_count": max(len(faith_scores), len(rel_scores)),
+        "eval_recall_mean": round(sum(recall_scores) / len(recall_scores), 4)
+        if recall_scores
+        else None,
+        "eval_mrr_mean": round(sum(mrr_scores) / len(mrr_scores), 4) if mrr_scores else None,
+        "eval_ndcg_mean": round(sum(ndcg_scores) / len(ndcg_scores), 4) if ndcg_scores else None,
+        "eval_count": max(len(faith_scores), len(rel_scores), len(recall_scores)),
         "op_mix": op_mix,
         "namespaces": ns_mix,
         "histogram": hist,
@@ -200,10 +211,19 @@ def aggregate_eval(
     win = [e for e in events if e.ts >= start]
 
     eval_events = [
-        e for e in win if e.eval_faithfulness is not None or e.eval_relevance is not None
+        e
+        for e in win
+        if e.eval_faithfulness is not None
+        or e.eval_relevance is not None
+        or e.eval_recall is not None
+        or e.eval_mrr is not None
+        or e.eval_ndcg is not None
     ]
     faith_scores = [e.eval_faithfulness for e in eval_events if e.eval_faithfulness is not None]
     rel_scores = [e.eval_relevance for e in eval_events if e.eval_relevance is not None]
+    recall_scores = [e.eval_recall for e in eval_events if e.eval_recall is not None]
+    mrr_scores = [e.eval_mrr for e in eval_events if e.eval_mrr is not None]
+    ndcg_scores = [e.eval_ndcg for e in eval_events if e.eval_ndcg is not None]
 
     pass_threshold = 0.7
     passed = [
@@ -211,6 +231,7 @@ def aggregate_eval(
         for e in eval_events
         if (e.eval_faithfulness is None or e.eval_faithfulness >= pass_threshold)
         and (e.eval_relevance is None or e.eval_relevance >= pass_threshold)
+        and (e.eval_recall is None or e.eval_recall >= pass_threshold)
     ]
 
     return {
@@ -219,6 +240,9 @@ def aggregate_eval(
         if faith_scores
         else None,
         "mean_relevance": round(sum(rel_scores) / len(rel_scores), 4) if rel_scores else None,
+        "mean_recall": round(sum(recall_scores) / len(recall_scores), 4) if recall_scores else None,
+        "mean_mrr": round(sum(mrr_scores) / len(mrr_scores), 4) if mrr_scores else None,
+        "mean_ndcg": round(sum(ndcg_scores) / len(ndcg_scores), 4) if ndcg_scores else None,
         "pass_rate": round(len(passed) / len(eval_events), 4) if eval_events else None,
         "pass_threshold": pass_threshold,
         "window_seconds": window_seconds,

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -3,11 +3,11 @@
 import sys
 from types import SimpleNamespace
 
-from dynavec.exceptions import MissingDependencyError
-from dynavec.ingest import MCPResourceSource, PDFSource, URLSource, Record, chunk_text, ingest
-from dynavec.models import UpsertResult
-
 import requests
+
+from dynavec.exceptions import MissingDependencyError
+from dynavec.ingest import MCPResourceSource, PDFSource, Record, URLSource, chunk_text, ingest
+from dynavec.models import UpsertResult
 
 
 def test_chunk_text_windows_with_overlap():

--- a/tests/test_retrieval_eval.py
+++ b/tests/test_retrieval_eval.py
@@ -1,0 +1,390 @@
+"""Comprehensive test suite for Information Retrieval (IR) quality evaluation (Recall, MRR, nDCG, Runner, Charts, Telemetry)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dynavec.dashboard import _make_handler
+from dynavec.eval import (
+    LabeledQuery,
+    RetrievalEvalRunner,
+    RetrievalEvalSummary,
+    RetrievalMetricResult,
+    compute_mrr,
+    compute_ndcg_at_k,
+    compute_precision_at_k,
+    compute_recall_at_k,
+    plot_retrieval_metrics,
+)
+from dynavec.exceptions import MissingDependencyError
+from dynavec.models import SearchResult
+from dynavec.telemetry import TelemetryRecorder, aggregate, aggregate_eval
+
+# ===========================================================================
+# 1. Mathematical Accuracy Tests for IR Metric Algorithms
+# ===========================================================================
+
+
+class TestIRMetricMath:
+    def test_recall_at_k(self) -> None:
+        retrieved = ["doc_a", "doc_b", "doc_c", "doc_d"]
+        relevant = {"doc_a", "doc_c"}
+
+        assert compute_recall_at_k(retrieved, relevant, k=1) == 0.5  # 1/2
+        assert compute_recall_at_k(retrieved, relevant, k=2) == 0.5  # 1/2
+        assert compute_recall_at_k(retrieved, relevant, k=3) == 1.0  # 2/2
+        assert compute_recall_at_k(retrieved, relevant, k=10) == 1.0
+
+    def test_recall_edge_cases(self) -> None:
+        assert compute_recall_at_k([], {"doc_a"}, k=5) == 0.0
+        assert compute_recall_at_k(["doc_a"], set(), k=5) == 0.0
+        assert compute_recall_at_k(["doc_a"], {"doc_a"}, k=0) == 0.0
+
+    def test_mrr_scoring(self) -> None:
+        retrieved = ["doc_a", "doc_b", "doc_c", "doc_d"]
+
+        # First relevant at rank 1 -> 1/1 = 1.0
+        assert compute_mrr(retrieved, {"doc_a", "doc_c"}) == 1.0
+        # First relevant at rank 2 -> 1/2 = 0.5
+        assert compute_mrr(retrieved, {"doc_b"}) == 0.5
+        # First relevant at rank 4 -> 1/4 = 0.25
+        assert compute_mrr(retrieved, {"doc_d"}) == 0.25
+        # None found in top-2 cutoff -> 0.0
+        assert compute_mrr(retrieved, {"doc_c"}, k=2) == 0.0
+        # None found anywhere -> 0.0
+        assert compute_mrr(retrieved, {"doc_x"}) == 0.0
+        assert compute_mrr([], {"doc_a"}) == 0.0
+
+    def test_ndcg_at_k_binary_relevance(self) -> None:
+        # Ideal ranking: relevant docs at positions 0 and 1
+        retrieved_ideal = ["doc_1", "doc_2", "doc_3", "doc_4"]
+        relevant = {"doc_1", "doc_2"}
+        assert compute_ndcg_at_k(retrieved_ideal, relevant, k=2) == 1.0
+        assert compute_ndcg_at_k(retrieved_ideal, relevant, k=4) == 1.0
+
+        # Suboptimal ranking: relevant docs at positions 1 and 3 (0-indexed)
+        retrieved_suboptimal = ["doc_x", "doc_1", "doc_y", "doc_2"]
+        score_k2 = compute_ndcg_at_k(retrieved_suboptimal, relevant, k=2)
+        score_k4 = compute_ndcg_at_k(retrieved_suboptimal, relevant, k=4)
+        assert 0.0 < score_k2 < 1.0
+        assert 0.0 < score_k4 < 1.0
+        assert score_k4 > score_k2  # second relevant item found at rank 4 increases score
+
+    def test_ndcg_at_k_graded_relevance(self) -> None:
+        grades = {"doc_high": 3.0, "doc_med": 2.0, "doc_low": 1.0}
+
+        # Perfect ranking: high (3) -> med (2) -> low (1)
+        ideal = ["doc_high", "doc_med", "doc_low", "doc_none"]
+        assert compute_ndcg_at_k(ideal, grades, k=3) == 1.0
+
+        # Inverted ranking: low (1) -> med (2) -> high (3)
+        inverted = ["doc_low", "doc_med", "doc_high", "doc_none"]
+        score = compute_ndcg_at_k(inverted, grades, k=3)
+        assert 0.0 < score < 1.0
+
+    def test_ndcg_edge_cases(self) -> None:
+        assert compute_ndcg_at_k([], {"doc_a": 1.0}, k=5) == 0.0
+        assert compute_ndcg_at_k(["doc_a"], {}, k=5) == 0.0
+        assert compute_ndcg_at_k(["doc_a"], {"doc_a": 0.0}, k=5) == 0.0
+        assert compute_ndcg_at_k(["doc_a"], {"doc_a": 1.0}, k=0) == 0.0
+
+    def test_precision_at_k(self) -> None:
+        retrieved = ["doc_1", "doc_2", "doc_x", "doc_y"]
+        relevant = {"doc_1", "doc_2", "doc_3"}
+
+        assert compute_precision_at_k(retrieved, relevant, k=2) == 1.0  # 2/2
+        assert compute_precision_at_k(retrieved, relevant, k=4) == 0.5  # 2/4
+        assert compute_precision_at_k(retrieved, set(), k=4) == 0.0
+
+
+# ===========================================================================
+# 2. Data Models & Dataset Loading Tests
+# ===========================================================================
+
+
+class TestRetrievalDataModelsAndLoading:
+    def test_labeled_query_creation_and_dict(self) -> None:
+        lq = LabeledQuery(
+            query="serverless vector database",
+            relevant_ids=["doc_1", "doc_2"],
+            relevance_grades={"doc_1": 2.0, "doc_2": 1.0},
+        )
+        assert lq.query_id.startswith("q_")
+        assert isinstance(lq.relevant_ids, set)
+        d = lq.to_dict()
+        assert d["query"] == "serverless vector database"
+        assert d["relevant_ids"] == ["doc_1", "doc_2"]
+
+    def test_summary_serialization_and_save_json(self, tmp_path) -> None:
+        r1 = RetrievalMetricResult(
+            query_id="q1",
+            query="test query",
+            retrieved_ids=["doc_1"],
+            recall_at_k={1: 1.0, 5: 1.0},
+            mrr=1.0,
+            ndcg_at_k={1: 1.0, 5: 1.0},
+            precision_at_k={1: 1.0, 5: 0.2},
+            latency_ms=15.2,
+        )
+        summary = RetrievalEvalSummary(
+            total_queries=1,
+            k_values=[1, 5],
+            mean_recall={1: 1.0, 5: 1.0},
+            mean_mrr=1.0,
+            mean_ndcg={1: 1.0, 5: 1.0},
+            mean_precision={1: 1.0, 5: 0.2},
+            p50_latency_ms=15.2,
+            p95_latency_ms=15.2,
+            results=[r1],
+        )
+
+        out_path = tmp_path / "eval_summary.json"
+        summary.save_json(out_path)
+
+        data = json.loads(out_path.read_text(encoding="utf-8"))
+        assert data["total_queries"] == 1
+        assert data["mean_mrr"] == 1.0
+        assert len(data["results"]) == 1
+
+    def test_load_dataset_json_array(self, tmp_path) -> None:
+        dataset = [
+            {"query": "q1", "relevant_ids": ["d1", "d2"]},
+            {"query": "q2", "relevant_ids": ["d3"], "relevance_grades": {"d3": 3.0}},
+        ]
+        json_file = tmp_path / "dataset.json"
+        json_file.write_text(json.dumps(dataset), encoding="utf-8")
+
+        loaded = RetrievalEvalRunner.load_dataset(json_file)
+        assert len(loaded) == 2
+        assert loaded[0].query == "q1"
+        assert loaded[1].relevance_grades == {"d3": 3.0}
+
+    def test_load_dataset_jsonl(self, tmp_path) -> None:
+        lines = [
+            json.dumps({"query": "q1", "relevant_ids": ["d1"]}),
+            json.dumps({"query": "q2", "relevant_ids": ["d2", "d3"]}),
+        ]
+        jsonl_file = tmp_path / "dataset.jsonl"
+        jsonl_file.write_text("\n".join(lines), encoding="utf-8")
+
+        loaded = RetrievalEvalRunner.load_dataset(jsonl_file)
+        assert len(loaded) == 2
+        assert "d1" in loaded[0].relevant_ids
+
+    def test_load_dataset_file_not_found_raises(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            RetrievalEvalRunner.load_dataset("non_existent_file.json")
+
+
+# ===========================================================================
+# 3. RetrievalEvalRunner Execution Tests
+# ===========================================================================
+
+
+class TestRetrievalEvalRunner:
+    def test_runner_with_callable_backend(self) -> None:
+        # Mock backend returning plain string IDs
+        def mock_search(query: str, top_k: int) -> list[str]:
+            if "dynavec" in query:
+                return ["doc_dynavec", "doc_other", "doc_noise"][:top_k]
+            return ["doc_random_1", "doc_random_2"][:top_k]
+
+        runner = RetrievalEvalRunner(search_backend=mock_search, k_values=[1, 3])
+        dataset = [
+            LabeledQuery(query="what is dynavec?", relevant_ids={"doc_dynavec"}),
+            LabeledQuery(query="other topic", relevant_ids={"doc_target"}),
+        ]
+
+        summary = runner.run(dataset)
+        assert summary.total_queries == 2
+        assert summary.k_values == [1, 3]
+        # Query 1: doc_dynavec at rank 1 (Recall@1=1.0, MRR=1.0)
+        # Query 2: doc_target not returned (Recall=0.0, MRR=0.0)
+        assert summary.mean_recall[1] == pytest.approx(0.5)
+        assert summary.mean_mrr == pytest.approx(0.5)
+        assert summary.p50_latency_ms >= 0.0
+
+    def test_runner_with_client_search_results(self) -> None:
+        class MockClient:
+            def search(
+                self, query: str, top_k: int = 10, namespace: str | None = None
+            ) -> list[SearchResult]:
+                return [
+                    SearchResult(id="doc_1", score=0.95, distance=0.05, text="text 1"),
+                    SearchResult(id="doc_2", score=0.85, distance=0.15, text="text 2"),
+                ][:top_k]
+
+        client = MockClient()
+        runner = RetrievalEvalRunner(search_backend=client, k_values=[1, 2])
+        dataset = [{"query": "test query", "relevant_ids": ["doc_2"]}]
+
+        summary = runner.run(dataset)
+        assert summary.total_queries == 1
+        # doc_2 is at rank 2: Recall@1 = 0.0, Recall@2 = 1.0, MRR = 0.5
+        assert summary.mean_recall[1] == 0.0
+        assert summary.mean_recall[2] == 1.0
+        assert summary.mean_mrr == 0.5
+
+    def test_runner_invalid_backend_raises(self) -> None:
+        runner = RetrievalEvalRunner(search_backend="not_a_searcher")
+        with pytest.raises(TypeError, match="must have a search"):
+            runner.run([{"query": "q", "relevant_ids": ["d"]}])
+
+
+# ===========================================================================
+# 4. Visual Charting Tests
+# ===========================================================================
+
+
+class TestPlotRetrievalMetrics:
+    def test_plot_missing_dependency_raises(self) -> None:
+        summary = RetrievalEvalSummary(
+            total_queries=1,
+            k_values=[1, 5],
+            mean_recall={1: 1.0, 5: 1.0},
+            mean_mrr=1.0,
+            mean_ndcg={1: 1.0, 5: 1.0},
+            mean_precision={1: 1.0, 5: 0.2},
+            p50_latency_ms=10.0,
+            p95_latency_ms=10.0,
+        )
+
+        with patch.dict("sys.modules", {"matplotlib": None}):
+            with pytest.raises(MissingDependencyError) as exc_info:
+                plot_retrieval_metrics(summary)
+            assert "matplotlib" in str(exc_info.value)
+            assert "benchmark" in str(exc_info.value)
+
+    def test_plot_mocked_generation(self) -> None:
+        summary = RetrievalEvalSummary(
+            total_queries=5,
+            k_values=[1, 3, 5, 10],
+            mean_recall={1: 0.5, 3: 0.7, 5: 0.85, 10: 0.95},
+            mean_mrr=0.72,
+            mean_ndcg={1: 0.5, 3: 0.68, 5: 0.81, 10: 0.91},
+            mean_precision={1: 0.5, 3: 0.35, 5: 0.25, 10: 0.15},
+            p50_latency_ms=12.0,
+            p95_latency_ms=25.0,
+        )
+
+        mock_fig = MagicMock()
+        mock_ax1 = MagicMock()
+        mock_ax2 = MagicMock()
+        mock_plt = MagicMock()
+        mock_plt.subplots.return_value = (mock_fig, (mock_ax1, mock_ax2))
+        mock_matplotlib = MagicMock()
+        mock_matplotlib.pyplot = mock_plt
+
+        with patch.dict(
+            "sys.modules", {"matplotlib": mock_matplotlib, "matplotlib.pyplot": mock_plt}
+        ):
+            saved_path = plot_retrieval_metrics(summary, output_path="retrieval_chart.png")
+            assert saved_path == "retrieval_chart.png"
+            mock_plt.savefig.assert_called_once_with("retrieval_chart.png", bbox_inches="tight")
+            mock_plt.close.assert_called_once_with(mock_fig)
+
+    def test_plot_empty_summary_raises(self) -> None:
+        mock_plt = MagicMock()
+        with patch.dict("sys.modules", {"matplotlib": MagicMock(), "matplotlib.pyplot": mock_plt}):
+            with pytest.raises(ValueError, match="Cannot plot empty retrieval evaluation summary"):
+                plot_retrieval_metrics(RetrievalEvalSummary(0, [], {}, 0.0, {}, {}, 0.0, 0.0))
+
+
+# ===========================================================================
+# 5. Telemetry & Dashboard Integration Tests
+# ===========================================================================
+
+
+class TestRetrievalTelemetryAndDashboard:
+    def test_telemetry_event_retrieval_fields(self) -> None:
+        rec = TelemetryRecorder()
+        ev = rec.new_event(
+            op="search",
+            namespace="docs",
+            latency_ms=30.0,
+            eval_recall=0.92,
+            eval_mrr=1.0,
+            eval_ndcg=0.88,
+        )
+        rec.record(ev)
+
+        assert ev.eval_recall == 0.92
+        assert ev.eval_mrr == 1.0
+        assert ev.eval_ndcg == 0.88
+
+        d = ev.to_dict()
+        assert d["eval_recall"] == 0.92
+        assert d["eval_mrr"] == 1.0
+        assert d["eval_ndcg"] == 0.88
+
+    def test_aggregate_with_retrieval_scores(self) -> None:
+        rec = TelemetryRecorder()
+        rec.record(rec.new_event("search", eval_recall=1.0, eval_mrr=1.0, eval_ndcg=0.9))
+        rec.record(rec.new_event("search", eval_recall=0.8, eval_mrr=0.5, eval_ndcg=0.7))
+        rec.record(rec.new_event("search"))  # unevaluated
+
+        stats = aggregate(rec.snapshot())
+        assert stats["eval_recall_mean"] == pytest.approx(0.9)
+        assert stats["eval_mrr_mean"] == pytest.approx(0.75)
+        assert stats["eval_ndcg_mean"] == pytest.approx(0.8)
+
+    def test_aggregate_eval_with_retrieval_scores(self) -> None:
+        rec = TelemetryRecorder()
+        rec.record(
+            rec.new_event("search", eval_recall=1.0, eval_mrr=1.0, eval_ndcg=0.9)
+        )  # pass (>=0.7)
+        rec.record(
+            rec.new_event("search", eval_recall=0.4, eval_mrr=0.5, eval_ndcg=0.5)
+        )  # fail (<0.7)
+
+        summary = aggregate_eval(rec.snapshot())
+        assert summary["total_evals"] == 2
+        assert summary["mean_recall"] == pytest.approx(0.7)
+        assert summary["mean_mrr"] == pytest.approx(0.75)
+        assert summary["mean_ndcg"] == pytest.approx(0.7)
+        assert summary["pass_rate"] == pytest.approx(0.5)
+
+    def test_dashboard_api_retrieval_eval_endpoints(self) -> None:
+        rec = TelemetryRecorder()
+        rec.record(
+            rec.new_event(
+                "search",
+                namespace="kb",
+                latency_ms=25.0,
+                eval_recall=0.95,
+                eval_mrr=1.0,
+                eval_ndcg=0.92,
+            )
+        )
+
+        handler_cls = _make_handler(rec)
+        handler = handler_cls.__new__(handler_cls)
+        handler.wfile = MagicMock()
+        sent_data = {}
+
+        def mock_send(code, body, ctype="application/json"):
+            sent_data["code"] = code
+            sent_data["body"] = json.loads(body)
+            sent_data["ctype"] = ctype
+
+        handler._send = mock_send
+
+        # Test GET /api/eval/summary
+        handler.path = "/api/eval/summary"
+        handler.do_GET()
+        assert sent_data["code"] == 200
+        assert sent_data["body"]["total_evals"] == 1
+        assert sent_data["body"]["mean_recall"] == 0.95
+        assert sent_data["body"]["mean_mrr"] == 1.0
+
+        # Test GET /api/eval/runs
+        handler.path = "/api/eval/runs"
+        handler.do_GET()
+        assert sent_data["code"] == 200
+        assert len(sent_data["body"]) == 1
+        assert sent_data["body"][0]["eval_recall"] == 0.95
+        assert sent_data["body"][0]["eval_mrr"] == 1.0
+        assert sent_data["body"][0]["eval_ndcg"] == 0.92


### PR DESCRIPTION
Resolves #134
Part of Epic #122

### Summary of Changes
- **Data Models:** Added `LabeledQuery`, `RetrievalMetricResult`, and `RetrievalEvalSummary` for standard ground-truth benchmark datasets and evaluation results.
- **IR Metrics:** Implemented zero-dependency mathematical evaluation functions: `compute_recall_at_k`, `compute_mrr`, `compute_ndcg_at_k` (binary & graded relevance), and `compute_precision_at_k`.
- **Runner & Dataset Loading:** Added `RetrievalEvalRunner` supporting live `Dynavec` search clients or custom callables, with dataset loading from JSON arrays, JSONL, and Python dicts/objects.
- **Visual Charting:** Added `plot_retrieval_metrics()` in `dynavec.eval.chart` rendering 2-panel metric curves and aggregate summary bar charts.
- **Telemetry & Dashboard:** Integrated retrieval metrics (`eval_recall`, `eval_mrr`, `eval_ndcg`) into `TelemetryEvent`, `aggregate()`, `aggregate_eval()`, and `/api/eval/*` endpoints with TypeScript definitions.
- **Tests:** Added comprehensive test suite in `tests/test_retrieval_eval.py` (22 unit tests, 100% pass rate).