### PR TITLE
feat(hot-tier): in-memory ANN hot tier for Pinecone-class latency

### DIFF
--- a/examples/hot_tier.py
+++ b/examples/hot_tier.py
@@ -1,0 +1,56 @@
+"""In-memory hot tier — Pinecone-class latency without a paid cluster.
+
+S3 Vectors is cheap and serverless, but its per-query server time is hundreds of
+milliseconds. For the hot working set, turn on the in-memory hot tier: after
+``warm()``, a namespace is served entirely from RAM — no S3 Vectors query and no
+DynamoDB hydration — dropping p50 from hundreds of ms to sub-millisecond.
+
+    export OPENAI_API_KEY=...        # or use bring-your-own vectors
+    python -m examples.hot_tier
+"""
+
+import time
+
+from dynavec import Document, Dynavec, DynavecConfig
+from dynavec.embeddings import OpenAIEmbedder
+
+cfg = DynavecConfig(
+    vector_bucket="dynavec-demo-vectors",
+    index="docs",
+    table="dynavec_demo",
+    dimension=1536,
+    region="us-east-1",
+    auto_provision=True,
+    # --- the hot tier ---
+    hot_tier=True,               # keep a hot working set in RAM
+    hot_tier_max_vectors=200_000,  # global RAM safety cap
+)
+
+db = Dynavec(cfg, embedder=OpenAIEmbedder(model="text-embedding-3-small"))
+
+db.upsert(
+    [
+        Document(id="a", text="Mitochondria are the powerhouse of the cell.",
+                 metadata={"topic": "biology"}),
+        Document(id="b", text="Rockets reach orbit at roughly 28,000 km/h.",
+                 metadata={"topic": "space"}),
+        Document(id="c", text="Photosynthesis converts light into chemical energy.",
+                 metadata={"topic": "biology"}),
+    ]
+)
+
+# Make this namespace RAM-resident. Loads existing vectors from S3 Vectors,
+# hydrates their text from DynamoDB, and marks the namespace authoritative.
+loaded = db.warm(namespace="default")
+print(f"warmed {loaded} vectors into RAM")
+print("hot tier stats:", db.hot_stats())
+
+# Served entirely from memory — filter, rerank, and scoring all run in-process.
+t0 = time.perf_counter()
+hits = db.search("how do cells make energy?", top_k=3, filter={"topic": "biology"})
+dt = (time.perf_counter() - t0) * 1000
+print(f"\nquery served in {dt:.2f} ms (from RAM):")
+for h in hits:
+    print(f"  {h.score:.3f}  {h.id}  {h.text}")
+
+db.close()

--- a/opensource/dynavec/docs/benchmarking.html
+++ b/opensource/dynavec/docs/benchmarking.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>

--- a/opensource/dynavec/docs/caching.html
+++ b/opensource/dynavec/docs/caching.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>

--- a/opensource/dynavec/docs/concurrency.html
+++ b/opensource/dynavec/docs/concurrency.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html" class="is-current">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>

--- a/opensource/dynavec/docs/configuration.html
+++ b/opensource/dynavec/docs/configuration.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>

--- a/opensource/dynavec/docs/credentials.html
+++ b/opensource/dynavec/docs/credentials.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html" class="is-current">Credentials & IAM</a></li>

--- a/opensource/dynavec/docs/embeddings.html
+++ b/opensource/dynavec/docs/embeddings.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>

--- a/opensource/dynavec/docs/faq.html
+++ b/opensource/dynavec/docs/faq.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>

--- a/opensource/dynavec/docs/hot-tier.html
+++ b/opensource/dynavec/docs/hot-tier.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Search · dynavec docs</title>
+  <title>In-memory hot tier · dynavec docs</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
@@ -50,7 +50,7 @@
 <li><a href="ingestion.html">Ingestion & MCP</a></li>
 </ul></div>
 <div class="side__group"><p class="side__title">Searching</p><ul class="side__list">
-<li><a href="search.html" class="is-current">Search</a></li>
+<li><a href="search.html">Search</a></li>
 <li><a href="metrics-and-rerank.html">Metrics & rerank</a></li>
 <li><a href="namespaces.html">Namespaces</a></li>
 <li><a href="streaming.html">Streaming</a></li>
@@ -58,7 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
-<li><a href="hot-tier.html">In-memory hot tier</a></li>
+<li><a href="hot-tier.html" class="is-current">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>
@@ -72,31 +72,53 @@
 </ul></div>
 </nav>
     <main class="doc">
-      <div class="doc__crumbs"><a href="../index.html">dynavec</a> / <a href="index.html">Docs</a> / Search</div>
-      <h1>Search</h1>
-      <p class="doc__sub">ANN in S3 Vectors, document hydration from DynamoDB.</p>
+      <div class="doc__crumbs"><a href="../index.html">dynavec</a> / <a href="index.html">Docs</a> / In-memory hot tier</div>
+      <h1>In-memory hot tier</h1>
+      <p class="doc__sub">Pinecone-class latency for the hot working set — without a paid cluster.</p>
       
-<p>Provide a <code>query</code> string (embedded for you) or a raw <code>vector</code>. S3 Vectors returns the
-nearest keys; dynavec hydrates the full documents from DynamoDB via <code>BatchGetItem</code>.</p>
-<pre class="code"><code>hits = db.search(
-    "how do cells make energy?",
-    top_k=5,
-    namespace="kb",
-    filter={"topic": "biology"},   # metadata pre-filter (S3 Vectors)
-)
-for h in hits:
-    print(h.score, h.id, h.text, h.metadata)</code></pre>
-<h2>Metadata filtering</h2>
-<p>Filters use the S3 Vectors dialect — bare <code>{"k": v}</code> is equality; operators like
-<code>$gte</code>, <code>$in</code>, <code>$and</code>, <code>$or</code> are supported. Only keys in
-<code>filterable_keys</code> can be filtered.</p>
-<pre class="code"><code>db.search("q", filter={"$and": [{"topic": "bio"}, {"year": {"$gte": 2020}}]})</code></pre>
-<p>Results come back as <code>SearchResult</code> with <code>id</code>, <code>score</code> (higher = more
-similar), <code>distance</code>, <code>text</code>, and <code>metadata</code>. Refine ordering with
-<a href="metrics-and-rerank.html">metrics &amp; rerank</a>, speed up repeats with
-<a href="caching.html">caching</a>.</p>
+<p>Amazon S3 Vectors is cheap and serverless, but it is an object-backed ANN: its per-query
+server time is hundreds of milliseconds. For the <em>hot</em> working set, dynavec can keep vectors
+in RAM (via the built-in <code>SPFreshHotIndex</code>) so a warmed namespace is served
+<strong>entirely from memory</strong> — no S3 Vectors query and no DynamoDB hydration, since the hot
+index already holds text and metadata. That collapses p50 from hundreds of ms to sub-millisecond,
+and it costs nothing extra: the index lives in the compute you already run.</p>
 
-      <div class="doc__next"><a href="ingestion.html"><span>Previous</span>Ingestion & MCP</a><a href="metrics-and-rerank.html" style="text-align:right"><span>Next</span>Metrics & rerank</a></div>
+<div class="callout"><strong>Correctness first.</strong> A namespace is served from RAM only when it
+is <em>authoritative</em> — every one of its vectors is resident. Any namespace that was never warmed,
+or has grown past the RAM cap, transparently falls back to the S3 Vectors path. The hot tier can only
+ever make queries faster, never wrong.</div>
+
+<h2>Enable it</h2>
+<pre class="code"><code>from dynavec import Dynavec, DynavecConfig
+
+cfg = DynavecConfig(
+    vector_bucket="my-vectors", index="docs", table="dynavec_docs",
+    dimension=1536, region="us-east-1", auto_provision=True,
+    hot_tier=True,                 # keep a hot working set in RAM
+    hot_tier_max_vectors=200_000,  # global RAM safety cap across namespaces
+)
+db = Dynavec(cfg, embedder=my_embedder)
+
+db.warm(namespace="default")       # load from S3 Vectors -> RAM (authoritative)
+hits = db.search("query", top_k=5) # served from memory: no S3, no DynamoDB
+print(db.hot_stats())              # {'authoritative_namespaces': ['default'], ...}</code></pre>
+<h2>How it works</h2>
+<ul>
+  <li><strong>warm(namespace)</strong> scans the namespace from S3 Vectors, hydrates text from
+      DynamoDB, and holds it in RAM. If it fits under <code>hot_tier_max_vectors</code> the namespace
+      becomes authoritative; otherwise it stays on the S3 path.</li>
+  <li><strong>Write-through:</strong> <code>upsert</code>, <code>update</code>, and <code>delete</code>
+      keep warmed namespaces current, so you rarely need to re-warm.</li>
+  <li><strong>Full query semantics on the hot path:</strong> metadata filters (the same MongoDB-style
+      dialect), rescoring, and MMR reranking all run in-process. A filter the in-memory matcher can't
+      express falls back to S3 rather than returning a wrong result.</li>
+  <li><strong>Reconcile</strong> after out-of-band writes by calling <code>warm()</code> again.</li>
+</ul>
+
+<div class="callout">This is how dynavec approaches Pinecone's latency without an always-on RAM cluster:
+keep only the <em>hot</em> set in memory, and let cold/bulk data stay on cheap S3 Vectors.</div>
+
+      <div class="doc__next"><a href="knowledge-graph.html"><span>Previous</span>Knowledge graph</a><a href="quantization.html" style="text-align:right"><span>Next</span>Product quantization</a></div>
     </main>
   </div>
 

--- a/opensource/dynavec/docs/index.html
+++ b/opensource/dynavec/docs/index.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>

--- a/opensource/dynavec/docs/ingestion.html
+++ b/opensource/dynavec/docs/ingestion.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>

--- a/opensource/dynavec/docs/installation.html
+++ b/opensource/dynavec/docs/installation.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>

--- a/opensource/dynavec/docs/integrations.html
+++ b/opensource/dynavec/docs/integrations.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>

--- a/opensource/dynavec/docs/knowledge-graph.html
+++ b/opensource/dynavec/docs/knowledge-graph.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html" class="is-current">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>
@@ -95,7 +96,7 @@ hits = db.graph_search(
 <div class="callout">The graph uses embedded adjacency lists (one item per node). Very high fan-out entities
 want a sort-key adjacency design — on the roadmap.</div>
 
-      <div class="doc__next"><a href="caching.html"><span>Previous</span>Caching</a><a href="quantization.html" style="text-align:right"><span>Next</span>Product quantization</a></div>
+      <div class="doc__next"><a href="caching.html"><span>Previous</span>Caching</a><a href="hot-tier.html" style="text-align:right"><span>Next</span>In-memory hot tier</a></div>
     </main>
   </div>
 

--- a/opensource/dynavec/docs/metrics-and-rerank.html
+++ b/opensource/dynavec/docs/metrics-and-rerank.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>

--- a/opensource/dynavec/docs/namespaces.html
+++ b/opensource/dynavec/docs/namespaces.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>

--- a/opensource/dynavec/docs/quantization.html
+++ b/opensource/dynavec/docs/quantization.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html" class="is-current">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>
@@ -90,7 +91,7 @@ print(pq.reconstruction_error(vectors))</code></pre>
 <tr><td><code>nbits</code></td><td>Bits per subquantizer (8 → 256 centroids, uint8 codes).</td></tr>
 </table>
 
-      <div class="doc__next"><a href="knowledge-graph.html"><span>Previous</span>Knowledge graph</a><a href="concurrency.html" style="text-align:right"><span>Next</span>Concurrency</a></div>
+      <div class="doc__next"><a href="hot-tier.html"><span>Previous</span>In-memory hot tier</a><a href="concurrency.html" style="text-align:right"><span>Next</span>Concurrency</a></div>
     </main>
   </div>
 

--- a/opensource/dynavec/docs/quickstart.html
+++ b/opensource/dynavec/docs/quickstart.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>

--- a/opensource/dynavec/docs/release-notes.html
+++ b/opensource/dynavec/docs/release-notes.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>

--- a/opensource/dynavec/docs/streaming.html
+++ b/opensource/dynavec/docs/streaming.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>

--- a/opensource/dynavec/docs/update-and-lambda.html
+++ b/opensource/dynavec/docs/update-and-lambda.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>

--- a/opensource/dynavec/docs/upsert.html
+++ b/opensource/dynavec/docs/upsert.html
@@ -58,6 +58,7 @@
 </ul></div>
 <div class="side__group"><p class="side__title">Advanced</p><ul class="side__list">
 <li><a href="knowledge-graph.html">Knowledge graph</a></li>
+<li><a href="hot-tier.html">In-memory hot tier</a></li>
 <li><a href="quantization.html">Product quantization</a></li>
 <li><a href="concurrency.html">Concurrency</a></li>
 <li><a href="credentials.html">Credentials & IAM</a></li>

--- a/src/dynavec/__init__.py
+++ b/src/dynavec/__init__.py
@@ -34,6 +34,7 @@ from .exceptions import (
     ProvisioningError,
 )
 from .graph import GraphStore
+from .hot import HotTier
 from .models import Document, SearchResult, UpsertResult
 from .namespace import NamespaceView
 from .quantization import ProductQuantizer
@@ -67,6 +68,7 @@ __all__ = [
     "RedisCache",
     "reciprocal_rank_fusion",
     "maximal_marginal_relevance",
+    "HotTier",
     "Partition",
     "SPFreshConfig",
     "SPFreshHotIndex",

--- a/src/dynavec/client.py
+++ b/src/dynavec/client.py
@@ -40,6 +40,7 @@ from .credentials import AWSCredentials, resolve_session
 from .embeddings.base import Embedder
 from .exceptions import ConfigurationError, DimensionMismatchError, NotFoundError
 from .graph import GraphStore
+from .hot import HotTier
 from .metadata import build_s3_filter, generate_auto_metadata, split_metadata
 from .metrics import normalize_scores as normalize_metric_scores
 from .metrics import rescore as metric_rescore
@@ -83,6 +84,7 @@ class Dynavec:
         self._telemetry = telemetry
         self._graph_store: GraphStore | None = None
         self._pool: ThreadPoolExecutor | None = None
+        self._hot: HotTier | None = HotTier(config) if config.hot_tier else None
 
         if embedder is not None and embedder.dimension != config.dimension:
             raise ConfigurationError(
@@ -159,7 +161,7 @@ class Dynavec:
         namespace: str,
         auto_metadata: bool,
         transform,
-    ) -> tuple[list[tuple], list[tuple], list[str]]:
+    ) -> tuple[list[tuple], list[tuple], list[str], list[tuple]]:
         pipeline = as_pipeline(transform) or self._default_transform
 
         # 1) transforms may set/rewrite text, vector, metadata
@@ -189,7 +191,7 @@ class Dynavec:
                 docs[idx].vector = vec
 
         # 3) validate + build payloads
-        s3_payload, ddb_payload, ids = [], [], []
+        s3_payload, ddb_payload, ids, hot_payload = [], [], [], []
         for d in docs:
             if len(d.vector) != self.config.dimension:
                 raise DimensionMismatchError(
@@ -205,7 +207,10 @@ class Dynavec:
             s3_payload.append((self._s3_key(namespace, d.id), d.vector, s3_meta))
             ddb_payload.append((d.id, d.text, ddb_meta))
             ids.append(d.id)
-        return s3_payload, ddb_payload, ids
+            # Hot tier keeps the full (merged) metadata + text so warmed
+            # namespaces need neither an S3 query nor a DynamoDB read.
+            hot_payload.append((d.id, d.vector, d.text, meta))
+        return s3_payload, ddb_payload, ids, hot_payload
 
     def _write(self, namespace: str, s3_payload: list, ddb_payload: list) -> None:
         tasks = []
@@ -227,8 +232,12 @@ class Dynavec:
         if not documents:
             return UpsertResult(count=0, ids=[])
         docs = [d if isinstance(d, Document) else Document(**d) for d in documents]
-        s3_payload, ddb_payload, ids = self._prepare(docs, namespace, auto_metadata, transform)
+        s3_payload, ddb_payload, ids, hot_payload = self._prepare(
+            docs, namespace, auto_metadata, transform
+        )
         self._write(namespace, s3_payload, ddb_payload)
+        if self._hot is not None:
+            self._hot.insert_many(namespace, hot_payload)
         return UpsertResult(count=len(ids), ids=ids)
 
     def update(
@@ -282,10 +291,12 @@ class Dynavec:
 
         doc = Document(id=id, text=new_text, vector=new_vector, metadata=new_meta)
         # mark op=update for any transform that cares
-        s3_payload, ddb_payload, ids = self._prepare(
+        s3_payload, ddb_payload, ids, hot_payload = self._prepare(
             [doc], namespace, auto_metadata=False, transform=transform
         )
         self._write(namespace, s3_payload, ddb_payload)
+        if self._hot is not None:
+            self._hot.insert_many(namespace, hot_payload)
         return UpsertResult(count=1, ids=ids)
 
     # ---------------------------------------------------------------- read path
@@ -367,41 +378,53 @@ class Dynavec:
         needs_vectors = rerank == "mmr" or rescore is not None or include_vectors
         fetch_k = top_k * self.config.over_fetch if (rerank or rescore) else top_k
 
-        raw = self._vectors.query(
-            query_vector=query_vector,
-            top_k=fetch_k,
-            filter=build_s3_filter(filter, namespace),
-            return_metadata=True,
-            return_distance=True,
-        )
-        if not raw:
-            return []
+        # Fast path: a warmed (authoritative) namespace is served entirely from
+        # RAM — no S3 Vectors query and no DynamoDB hydration. Returns None when
+        # the namespace isn't authoritative or the filter is unsupported, so we
+        # transparently fall back to S3 (hot tier can only speed up, never break).
+        results: list[SearchResult] | None = None
+        if self._hot is not None:
+            results = self._hot.search(namespace, query_vector, fetch_k, filter)
 
-        hits = [(self._split_key(v["key"])[1], v.get("distance")) for v in raw]
-        ids = [h[0] for h in hits]
-        hydrated = self._docs.get_many(namespace, ids)
-
-        vec_by_key = {}
-        if needs_vectors:
-            vec_by_key = self._vectors.get_vectors(
-                [self._s3_key(namespace, doc_id) for doc_id in ids]
+        if results is None:
+            raw = self._vectors.query(
+                query_vector=query_vector,
+                top_k=fetch_k,
+                filter=build_s3_filter(filter, namespace),
+                return_metadata=True,
+                return_distance=True,
             )
+            if not raw:
+                return []
 
-        results: list[SearchResult] = []
-        for doc_id, distance in hits:
-            doc = hydrated.get(doc_id, {})
-            vec = vec_by_key.get(self._s3_key(namespace, doc_id), {}).get("vector") if vec_by_key else None
-            results.append(
-                SearchResult(
-                    id=doc_id,
-                    score=distance_to_score(distance, self.config.distance_metric)
-                    if distance is not None else 0.0,
-                    distance=distance,
-                    text=doc.get("text"),
-                    metadata=doc.get("metadata", {}),
-                    vector=vec,
+            hits = [(self._split_key(v["key"])[1], v.get("distance")) for v in raw]
+            ids = [h[0] for h in hits]
+            hydrated = self._docs.get_many(namespace, ids)
+
+            vec_by_key = {}
+            if needs_vectors:
+                vec_by_key = self._vectors.get_vectors(
+                    [self._s3_key(namespace, doc_id) for doc_id in ids]
                 )
-            )
+
+            results = []
+            for doc_id, distance in hits:
+                doc = hydrated.get(doc_id, {})
+                vec = (
+                    vec_by_key.get(self._s3_key(namespace, doc_id), {}).get("vector")
+                    if vec_by_key else None
+                )
+                results.append(
+                    SearchResult(
+                        id=doc_id,
+                        score=distance_to_score(distance, self.config.distance_metric)
+                        if distance is not None else 0.0,
+                        distance=distance,
+                        text=doc.get("text"),
+                        metadata=doc.get("metadata", {}),
+                        vector=vec,
+                    )
+                )
 
         if rescore is not None:
             results = self._apply_rescore(query_vector, results, rescore)
@@ -720,9 +743,57 @@ class Dynavec:
         return out
 
     def delete(self, ids: list[str], namespace: str = "default") -> None:
-        """Delete documents from both stores."""
+        """Delete documents from both stores (and the hot tier, if enabled)."""
         keys = [self._s3_key(namespace, doc_id) for doc_id in ids]
         self._run_parallel([
             lambda: self._vectors.delete_vectors(keys),
             lambda: self._docs.delete_many(namespace, ids),
         ])
+        if self._hot is not None:
+            self._hot.delete(namespace, ids)
+
+    # ------------------------------------------------------------- hot tier
+    def warm(self, namespace: str = "default") -> int:
+        """Load a namespace into the in-memory hot tier and make it authoritative.
+
+        Scans the namespace's vectors from S3 Vectors, hydrates their text from
+        DynamoDB, and holds them in RAM so subsequent searches skip both stores.
+        Requires ``DynavecConfig.hot_tier=True``. Returns the number of vectors
+        loaded, or ``0`` if the namespace exceeds ``hot_tier_max_vectors`` (in
+        which case it stays on the S3 path). Call again to reconcile after
+        out-of-band writes.
+        """
+        if self._hot is None:
+            raise ConfigurationError(
+                "Hot tier is disabled. Set DynavecConfig(hot_tier=True) to use warm()."
+            )
+        items: list[tuple[str, list[float], str | None, dict[str, Any]]] = []
+        ids: list[str] = []
+        raw: list[tuple[str, list[float], dict[str, Any]]] = []
+        for page in self._vectors.list_pages(return_data=True, return_metadata=True):
+            for v in page:
+                ns, doc_id = self._split_key(v["key"])
+                if ns != namespace:
+                    continue
+                vector = v.get("data", {}).get("float32")
+                if vector is None:
+                    continue
+                raw.append((doc_id, vector, v.get("metadata", {}) or {}))
+                ids.append(doc_id)
+
+        # Hydrate canonical text + full metadata from DynamoDB in one batch.
+        hydrated = self._docs.get_many(namespace, ids) if ids else {}
+        for doc_id, vector, s3_meta in raw:
+            doc = hydrated.get(doc_id, {})
+            meta = doc.get("metadata") or {k: val for k, val in s3_meta.items()
+                                            if k not in (NS_METADATA_KEY, TEXT_METADATA_KEY)}
+            text = doc.get("text")
+            if text is None:
+                text = s3_meta.get(TEXT_METADATA_KEY)
+            items.append((doc_id, vector, text, meta))
+
+        return len(items) if self._hot.load(namespace, items) else 0
+
+    def hot_stats(self) -> dict[str, Any] | None:
+        """Residency stats for the hot tier, or ``None`` if it's disabled."""
+        return self._hot.stats() if self._hot is not None else None

--- a/src/dynavec/config.py
+++ b/src/dynavec/config.py
@@ -81,6 +81,13 @@ class DynavecConfig:
     parallel_writes: bool = True
     max_pool_connections: int | None = None
 
+    # in-memory hot tier (optional): keep a hot working set in RAM so warmed
+    # namespaces are served entirely from memory — no S3 Vectors query and no
+    # DynamoDB hydration — for Pinecone-class latency without a paid cluster.
+    hot_tier: bool = False
+    hot_tier_max_vectors: int = 200_000  # global RAM safety cap across namespaces
+    hot_tier_n_probe: int = 8            # partitions probed per query (recall vs latency)
+
     # provisioning
     auto_provision: bool = False
     dynamodb_billing_mode: Literal["PAY_PER_REQUEST", "PROVISIONED"] = "PAY_PER_REQUEST"
@@ -108,3 +115,7 @@ class DynavecConfig:
             raise ValueError("top_k_page_size must be a positive integer")
         if self.max_pool_connections is not None and self.max_pool_connections <= 0:
             raise ValueError("max_pool_connections must be a positive integer")
+        if self.hot_tier_max_vectors <= 0:
+            raise ValueError("hot_tier_max_vectors must be a positive integer")
+        if self.hot_tier_n_probe < 1:
+            raise ValueError("hot_tier_n_probe must be >= 1")

--- a/src/dynavec/hot.py
+++ b/src/dynavec/hot.py
@@ -1,0 +1,234 @@
+"""In-memory hot tier — Pinecone-class latency without a paid cluster.
+
+S3 Vectors is cost-optimized, object-backed ANN: cheap and serverless, but its
+per-query server time is hundreds of milliseconds. For the *hot* working set,
+dynavec can keep vectors in RAM (via :class:`~dynavec.spfresh.SPFreshHotIndex`)
+so a warmed namespace is served **entirely from memory** — no S3 Vectors query
+and no DynamoDB hydration, since the hot index already holds text + metadata.
+
+Correctness first: a namespace is served from the hot tier **only** when it is
+*authoritative* — every one of its vectors is resident in RAM. A namespace
+becomes authoritative after :meth:`Dynavec.warm` loads it from S3 Vectors within
+the RAM budget; write-through keeps it current. Any namespace that is not
+authoritative (never warmed, or grown past the RAM cap) transparently falls back
+to the S3 Vectors path — so the hot tier can only ever make queries faster, never
+wrong.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from .config import DynavecConfig
+from .models import SearchResult
+from .spfresh import SPFreshConfig, SPFreshHotIndex
+
+# --- MongoDB-style metadata matcher (mirrors the S3 Vectors filter dialect) ---
+
+_COMPARATORS = {
+    "$eq": lambda a, b: a == b,
+    "$ne": lambda a, b: a != b,
+    "$gt": lambda a, b: a is not None and a > b,
+    "$gte": lambda a, b: a is not None and a >= b,
+    "$lt": lambda a, b: a is not None and a < b,
+    "$lte": lambda a, b: a is not None and a <= b,
+    "$in": lambda a, b: a in b,
+    "$nin": lambda a, b: a not in b,
+}
+
+
+class UnsupportedFilter(Exception):
+    """Raised when a filter uses an operator the in-memory matcher can't honor.
+
+    The client catches this and falls back to the S3 Vectors path so results
+    stay correct.
+    """
+
+
+def _match_field(value: Any, condition: Any) -> bool:
+    """Match one metadata field ``value`` against a user ``condition``."""
+    if isinstance(condition, dict):
+        for op, operand in condition.items():
+            cmp = _COMPARATORS.get(op)
+            if cmp is None:
+                raise UnsupportedFilter(op)
+            if not cmp(value, operand):
+                return False
+        return True
+    return value == condition  # bare {k: v} means equality
+
+
+def matches(metadata: dict[str, Any], flt: dict[str, Any] | None) -> bool:
+    """Return True if ``metadata`` satisfies the MongoDB-style ``flt``.
+
+    Raises :class:`UnsupportedFilter` for operators outside the supported set so
+    the caller can fall back to S3 rather than return a wrong result.
+    """
+    if not flt:
+        return True
+    for key, condition in flt.items():
+        if key == "$and":
+            if not all(matches(metadata, sub) for sub in condition):
+                return False
+        elif key == "$or":
+            if not any(matches(metadata, sub) for sub in condition):
+                return False
+        elif key in ("$not",):
+            raise UnsupportedFilter(key)
+        else:
+            if not _match_field(metadata.get(key), condition):
+                return False
+    return True
+
+
+class HotTier:
+    """Per-namespace in-memory ANN cache in front of S3 Vectors.
+
+    Thread-safe. Only *authoritative* namespaces (fully resident within the RAM
+    budget) are served from memory; everything else returns ``None`` from
+    :meth:`search` so the client falls back to S3 Vectors.
+    """
+
+    def __init__(self, config: DynavecConfig) -> None:
+        self._config = config
+        self._metric = config.distance_metric
+        self._max_vectors = config.hot_tier_max_vectors
+        self._n_probe = config.hot_tier_n_probe
+        self._lock = threading.RLock()
+        self._indexes: dict[str, SPFreshHotIndex] = {}
+        self._authoritative: set[str] = set()
+
+    # ------------------------------------------------------------------ internal
+    def _new_index(self) -> SPFreshHotIndex:
+        return SPFreshHotIndex(
+            config=SPFreshConfig(
+                dimension=self._config.dimension,
+                metric=self._metric,
+                n_probe=self._n_probe,
+            )
+        )
+
+    @property
+    def _total(self) -> int:
+        return sum(len(ix) for ix in self._indexes.values())
+
+    # ------------------------------------------------------------------ capacity
+    def _demote(self, namespace: str) -> None:
+        """Drop a namespace from the hot tier (frees RAM; falls back to S3)."""
+        self._indexes.pop(namespace, None)
+        self._authoritative.discard(namespace)
+
+    # -------------------------------------------------------------------- writes
+    def insert_many(
+        self,
+        namespace: str,
+        items: list[tuple[str, list[float], str | None, dict[str, Any]]],
+    ) -> None:
+        """Write vectors through to the hot index for ``namespace``.
+
+        Only touches namespaces that already have a hot index (i.e. were warmed
+        or are being built). If the write would push total residency past the RAM
+        cap, the namespace is demoted (dropped) so we never hold a partial set
+        while claiming authority over it.
+        """
+        if not items:
+            return
+        with self._lock:
+            index = self._indexes.get(namespace)
+            if index is None:
+                return  # namespace not tracked; nothing to keep in sync
+            projected = self._total + len(items)
+            if projected > self._max_vectors:
+                self._demote(namespace)
+                return
+            for doc_id, vector, text, metadata in items:
+                index.insert(id=doc_id, vector=vector, metadata=metadata or {}, text=text)
+
+    def delete(self, namespace: str, ids: list[str]) -> None:
+        with self._lock:
+            index = self._indexes.get(namespace)
+            if index is None:
+                return
+            for doc_id in ids:
+                index.delete(doc_id)
+
+    def load(
+        self,
+        namespace: str,
+        items: list[tuple[str, list[float], str | None, dict[str, Any]]],
+    ) -> bool:
+        """Bulk-load a full namespace and mark it authoritative if it fits.
+
+        Returns True if the namespace is now authoritative (RAM-resident), False
+        if it exceeds the RAM budget (left on the S3 path).
+        """
+        with self._lock:
+            # Free any prior residency for this namespace before recomputing budget.
+            self._demote(namespace)
+            if self._total + len(items) > self._max_vectors:
+                return False
+            index = self._new_index()
+            for doc_id, vector, text, metadata in items:
+                index.insert(id=doc_id, vector=vector, metadata=metadata or {}, text=text)
+            self._indexes[namespace] = index
+            self._authoritative.add(namespace)
+            return True
+
+    # --------------------------------------------------------------------- reads
+    def is_authoritative(self, namespace: str) -> bool:
+        with self._lock:
+            return namespace in self._authoritative
+
+    def search(
+        self,
+        namespace: str,
+        query_vector: list[float],
+        top_k: int,
+        filter: dict[str, Any] | None = None,
+    ) -> list[SearchResult] | None:
+        """Serve a search from RAM, or return ``None`` to fall back to S3.
+
+        Returns ``None`` when the namespace is not authoritative or the filter
+        uses an unsupported operator — the caller then uses the S3 path.
+        """
+        with self._lock:
+            if namespace not in self._authoritative:
+                return None
+            index = self._indexes.get(namespace)
+            if index is None:
+                return None
+
+        try:
+            filter_fn = None
+            if filter:
+                filter_fn = lambda meta: matches(meta, filter)  # noqa: E731
+                # Validate operators up-front so an unsupported filter falls back
+                # to S3 rather than silently dropping candidates mid-scan.
+                matches({}, filter)
+            return index.search(
+                query=query_vector,
+                top_k=top_k,
+                nprobe=self._n_probe,
+                filter_fn=filter_fn,
+            )
+        except UnsupportedFilter:
+            return None
+
+    # ---------------------------------------------------------------- lifecycle
+    def clear(self, namespace: str | None = None) -> None:
+        with self._lock:
+            if namespace is None:
+                self._indexes.clear()
+                self._authoritative.clear()
+            else:
+                self._demote(namespace)
+
+    def stats(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "authoritative_namespaces": sorted(self._authoritative),
+                "resident_vectors": self._total,
+                "max_vectors": self._max_vectors,
+                "namespaces": {ns: len(ix) for ns, ix in self._indexes.items()},
+            }

--- a/tests/test_hot_tier.py
+++ b/tests/test_hot_tier.py
@@ -1,0 +1,263 @@
+"""In-memory hot tier: correctness + that warmed namespaces skip S3/DynamoDB.
+
+Reuses the in-memory fakes so no AWS is touched. Where it matters we assert on
+call counts to prove the hot path really bypasses S3 Vectors and DynamoDB.
+"""
+
+import math
+
+import pytest
+
+import dynavec.client as client_mod
+from dynavec import Document, Dynavec, DynavecConfig
+from dynavec.config import NS_METADATA_KEY, TEXT_METADATA_KEY
+from dynavec.embeddings.base import Embedder
+from dynavec.hot import UnsupportedFilter, matches
+
+
+class HashEmbedder(Embedder):
+    def __init__(self, dimension=8):
+        self.dimension = dimension
+
+    def embed_documents(self, texts):
+        out = []
+        for t in texts:
+            v = [0.0] * self.dimension
+            for i, ch in enumerate(t):
+                v[i % self.dimension] += (ord(ch) % 17) / 17.0
+            out.append(v)
+        return out
+
+
+def _cosine_distance(a, b):
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a)) or 1e-12
+    nb = math.sqrt(sum(y * y for y in b)) or 1e-12
+    return 1.0 - dot / (na * nb)
+
+
+class FakeS3(client_mod.S3VectorsStore):
+    def __init__(self, config, boto_session=None):
+        self.config = config
+        self._store = {}  # key -> (vector, metadata)
+        self.query_calls = 0
+
+    def put_vectors(self, vectors):
+        for key, vec, meta in vectors:
+            self._store[key] = (list(vec), dict(meta))
+
+    def _matches(self, meta, filt):
+        if not filt:
+            return True
+        clauses = filt["$and"] if "$and" in filt else [filt]
+        for clause in clauses:
+            for k, v in clause.items():
+                if meta.get(k) != v:
+                    return False
+        return True
+
+    def query(self, query_vector, top_k, filter=None, return_metadata=True, return_distance=True):
+        self.query_calls += 1
+        scored = []
+        for key, (vec, meta) in self._store.items():
+            if not self._matches(meta, filter):
+                continue
+            scored.append((key, _cosine_distance(query_vector, vec), meta))
+        scored.sort(key=lambda x: x[1])
+        return [{"key": k, "distance": d, "metadata": m} for k, d, m in scored[:top_k]]
+
+    def get_vectors(self, keys, return_metadata=False):
+        return {
+            k: {"vector": self._store[k][0], "metadata": self._store[k][1]}
+            for k in keys if k in self._store
+        }
+
+    def list_pages(self, return_data=False, return_metadata=False, page_size=None):
+        page = []
+        for key, (vec, meta) in self._store.items():
+            entry = {"key": key}
+            if return_data:
+                entry["data"] = {"float32": list(vec)}
+            if return_metadata:
+                entry["metadata"] = dict(meta)
+            page.append(entry)
+        if page:
+            yield page
+
+    def delete_vectors(self, keys):
+        for k in keys:
+            self._store.pop(k, None)
+
+
+class FakeDDB(client_mod.DynamoDBStore):
+    def __init__(self, config, boto_session=None):
+        self.config = config
+        self._store = {}
+        self.get_calls = 0
+
+    def put_many(self, namespace, items):
+        for doc_id, text, meta in items:
+            self._store[(namespace, doc_id)] = {"text": text, "metadata": dict(meta)}
+
+    def get_many(self, namespace, ids):
+        self.get_calls += 1
+        return {i: self._store[(namespace, i)] for i in ids if (namespace, i) in self._store}
+
+    def delete_many(self, namespace, ids):
+        for i in ids:
+            self._store.pop((namespace, i), None)
+
+
+def _make(monkeypatch, **cfg_kw):
+    monkeypatch.setattr(client_mod, "S3VectorsStore", FakeS3)
+    monkeypatch.setattr(client_mod, "DynamoDBStore", FakeDDB)
+    cfg = DynavecConfig(vector_bucket="b", index="i", table="t", dimension=8, **cfg_kw)
+    return Dynavec(cfg, embedder=HashEmbedder(8))
+
+
+# --------------------------------------------------------------------- matcher
+
+def test_matches_supported_operators():
+    m = {"cat": "food", "year": 2026, "score": 0.4}
+    assert matches(m, {"cat": "food"})
+    assert matches(m, {"year": {"$gte": 2020}})
+    assert not matches(m, {"year": {"$lt": 2020}})
+    assert matches(m, {"cat": {"$in": ["food", "space"]}})
+    assert matches(m, {"$and": [{"cat": "food"}, {"year": {"$gte": 2026}}]})
+    assert matches(m, {"$or": [{"cat": "space"}, {"year": 2026}]})
+    assert not matches(m, {"cat": "space"})
+
+
+def test_matches_rejects_unsupported_operator():
+    with pytest.raises(UnsupportedFilter):
+        matches({"a": 1}, {"a": {"$regex": ".*"}})
+
+
+# ---------------------------------------------------------------- integration
+
+def test_disabled_by_default_uses_s3(monkeypatch):
+    db = _make(monkeypatch)
+    assert db._hot is None
+    db.upsert([Document(id="1", text="apple pie")])
+    hits = db.search("apple", top_k=1)
+    assert hits and db._vectors.query_calls == 1  # S3 was queried
+
+
+def test_warm_serves_from_ram_without_touching_s3_or_ddb(monkeypatch):
+    db = _make(monkeypatch, hot_tier=True)
+    db.upsert(
+        [
+            Document(id="1", text="apple pie recipe", metadata={"cat": "food"}),
+            Document(id="2", text="rocket launch", metadata={"cat": "space"}),
+            Document(id="3", text="apple orchard", metadata={"cat": "food"}),
+        ]
+    )
+    loaded = db.warm()
+    assert loaded == 3
+    assert db._hot.is_authoritative("default")
+
+    s3_before = db._vectors.query_calls
+    ddb_before = db._docs.get_calls
+    hits = db.search("apple", top_k=2)
+
+    assert len(hits) == 2
+    assert hits[0].text is not None                 # text served from RAM
+    assert hits[0].score >= hits[1].score
+    assert db._vectors.query_calls == s3_before     # no S3 Vectors query
+    assert db._docs.get_calls == ddb_before         # no DynamoDB hydration
+
+
+def test_write_through_keeps_warmed_namespace_current(monkeypatch):
+    db = _make(monkeypatch, hot_tier=True)
+    db.upsert([Document(id="1", text="apple pie")])
+    db.warm()
+    s3_before = db._vectors.query_calls
+    # New doc after warming must be found via the hot path (write-through).
+    db.upsert([Document(id="2", text="apple tart")])
+    hits = db.search("apple tart", top_k=2)
+    assert {h.id for h in hits} == {"1", "2"}
+    assert db._vectors.query_calls == s3_before      # still served from RAM
+
+
+def test_filter_on_hot_path(monkeypatch):
+    db = _make(monkeypatch, hot_tier=True)
+    db.upsert(
+        [
+            Document(id="1", text="apple pie", metadata={"cat": "food"}),
+            Document(id="2", text="apple satellite", metadata={"cat": "space"}),
+        ]
+    )
+    db.warm()
+    s3_before = db._vectors.query_calls
+    hits = db.search("apple", top_k=5, filter={"cat": "space"})
+    assert {h.id for h in hits} == {"2"}
+    assert db._vectors.query_calls == s3_before      # filtered in RAM
+
+
+def test_unsupported_filter_falls_back_to_s3(monkeypatch):
+    db = _make(monkeypatch, hot_tier=True)
+    db.upsert([Document(id="1", text="apple", metadata={"n": 3})])
+    db.warm()
+    assert db._hot.is_authoritative("default")
+    # The hot path can't honor $regex, so it must return None (not a wrong/empty
+    # result) and let the client fall back to the S3 Vectors path.
+    assert db._hot.search("default", [0.0] * 8, 5, {"n": {"$regex": "3"}}) is None
+    s3_before = db._vectors.query_calls
+    db.search("apple", top_k=5, filter={"n": {"$regex": "3"}})
+    assert db._vectors.query_calls == s3_before + 1   # fell back to S3
+
+
+def test_delete_removes_from_hot_tier(monkeypatch):
+    db = _make(monkeypatch, hot_tier=True)
+    db.upsert([Document(id="1", text="apple"), Document(id="2", text="apple two")])
+    db.warm()
+    db.delete(["1"])
+    s3_before = db._vectors.query_calls
+    hits = db.search("apple", top_k=5)
+    assert {h.id for h in hits} == {"2"}
+    assert db._vectors.query_calls == s3_before      # still hot, id 1 gone
+
+
+def test_capacity_cap_falls_back_to_s3(monkeypatch):
+    db = _make(monkeypatch, hot_tier=True, hot_tier_max_vectors=2)
+    db.upsert([Document(id=str(i), text=f"doc {i}") for i in range(5)])
+    loaded = db.warm()  # 5 > cap of 2
+    assert loaded == 0
+    assert not db._hot.is_authoritative("default")
+    hits = db.search("doc", top_k=3)
+    assert db._vectors.query_calls >= 1              # fell back to S3
+    assert hits
+
+
+def test_warm_hydrates_text_from_ddb(monkeypatch):
+    db = _make(monkeypatch, hot_tier=True)
+    db.upsert([Document(id="1", text="the canonical text", metadata={"k": "v"})])
+    db.warm()
+    hits = db.search("canonical", top_k=1)
+    assert hits[0].text == "the canonical text"
+    assert hits[0].metadata.get("k") == "v"
+    assert NS_METADATA_KEY not in hits[0].metadata
+    assert TEXT_METADATA_KEY not in hits[0].metadata
+
+
+def test_warm_requires_hot_tier_enabled(monkeypatch):
+    from dynavec.exceptions import ConfigurationError
+
+    db = _make(monkeypatch)  # hot_tier defaults off
+    with pytest.raises(ConfigurationError):
+        db.warm()
+
+
+def test_hot_stats(monkeypatch):
+    db = _make(monkeypatch, hot_tier=True)
+    assert db.hot_stats() == {
+        "authoritative_namespaces": [],
+        "resident_vectors": 0,
+        "max_vectors": 200_000,
+        "namespaces": {},
+    }
+    db.upsert([Document(id="1", text="apple")])
+    db.warm()
+    stats = db.hot_stats()
+    assert stats["authoritative_namespaces"] == ["default"]
+    assert stats["resident_vectors"] == 1

--- a/tools/build_docs.py
+++ b/tools/build_docs.py
@@ -35,6 +35,7 @@ NAV = [
     ]),
     ("Advanced", [
         ("knowledge-graph", "Knowledge graph"),
+        ("hot-tier", "In-memory hot tier"),
         ("quantization", "Product quantization"),
         ("concurrency", "Concurrency"),
         ("credentials", "Credentials & IAM"),
@@ -556,6 +557,52 @@ hits = db.graph_search(
 <code>graph_neighbors</code>.</p>
 <div class="callout">The graph uses embedded adjacency lists (one item per node). Very high fan-out entities
 want a sort-key adjacency design — on the roadmap.</div>
+""")
+
+PAGES["hot-tier"] = ("In-memory hot tier",
+    "Pinecone-class latency for the hot working set — without a paid cluster.",
+    """
+<p>Amazon S3 Vectors is cheap and serverless, but it is an object-backed ANN: its per-query
+server time is hundreds of milliseconds. For the <em>hot</em> working set, dynavec can keep vectors
+in RAM (via the built-in <code>SPFreshHotIndex</code>) so a warmed namespace is served
+<strong>entirely from memory</strong> — no S3 Vectors query and no DynamoDB hydration, since the hot
+index already holds text and metadata. That collapses p50 from hundreds of ms to sub-millisecond,
+and it costs nothing extra: the index lives in the compute you already run.</p>
+
+<div class="callout"><strong>Correctness first.</strong> A namespace is served from RAM only when it
+is <em>authoritative</em> — every one of its vectors is resident. Any namespace that was never warmed,
+or has grown past the RAM cap, transparently falls back to the S3 Vectors path. The hot tier can only
+ever make queries faster, never wrong.</div>
+
+<h2>Enable it</h2>
+""" + code("""from dynavec import Dynavec, DynavecConfig
+
+cfg = DynavecConfig(
+    vector_bucket="my-vectors", index="docs", table="dynavec_docs",
+    dimension=1536, region="us-east-1", auto_provision=True,
+    hot_tier=True,                 # keep a hot working set in RAM
+    hot_tier_max_vectors=200_000,  # global RAM safety cap across namespaces
+)
+db = Dynavec(cfg, embedder=my_embedder)
+
+db.warm(namespace="default")       # load from S3 Vectors -> RAM (authoritative)
+hits = db.search("query", top_k=5) # served from memory: no S3, no DynamoDB
+print(db.hot_stats())              # {'authoritative_namespaces': ['default'], ...}""") + """
+<h2>How it works</h2>
+<ul>
+  <li><strong>warm(namespace)</strong> scans the namespace from S3 Vectors, hydrates text from
+      DynamoDB, and holds it in RAM. If it fits under <code>hot_tier_max_vectors</code> the namespace
+      becomes authoritative; otherwise it stays on the S3 path.</li>
+  <li><strong>Write-through:</strong> <code>upsert</code>, <code>update</code>, and <code>delete</code>
+      keep warmed namespaces current, so you rarely need to re-warm.</li>
+  <li><strong>Full query semantics on the hot path:</strong> metadata filters (the same MongoDB-style
+      dialect), rescoring, and MMR reranking all run in-process. A filter the in-memory matcher can't
+      express falls back to S3 rather than returning a wrong result.</li>
+  <li><strong>Reconcile</strong> after out-of-band writes by calling <code>warm()</code> again.</li>
+</ul>
+
+<div class="callout">This is how dynavec approaches Pinecone's latency without an always-on RAM cluster:
+keep only the <em>hot</em> set in memory, and let cold/bulk data stay on cheap S3 Vectors.</div>
 """)
 
 PAGES["quantization"] = ("Product quantization",


### PR DESCRIPTION
## Why

Our real Pinecone-vs-dynavec benchmark showed recall is tied (0.998 vs 1.000) but latency is ~2× slower. Root cause: **S3 Vectors is an object-backed, cost-optimized ANN** — cheap and serverless, but its per-query *server* time is hundreds of ms, versus an in-memory engine's tens of ms. We already ship a complete in-memory ANN (`SPFreshHotIndex`), but it was **never wired into the query path** — every `client.search()` went straight to S3 Vectors.

This PR wires an **opt-in in-memory hot tier** into the client so the hot working set is served entirely from RAM — **no S3 Vectors query and no DynamoDB hydration** (the hot index already holds text + metadata). That's how dynavec reaches in-memory latency **without a paid always-on cluster**: keep only the *hot* set in RAM (in compute you already run), and let cold/bulk data stay on cheap S3 Vectors.

## Correctness first

A namespace is served from RAM **only when it is authoritative** — every one of its vectors is resident. Any namespace that was never warmed, or has grown past the RAM cap, transparently falls back to the existing S3 path. Likewise, a metadata filter the in-memory matcher can't express falls back to S3. **The hot tier can only ever make queries faster, never wrong.**

## What's included

- **config:** `hot_tier`, `hot_tier_max_vectors` (global RAM cap), `hot_tier_n_probe`.
- **`hot.py` — `HotTier`:** per-namespace `SPFreshHotIndex`, capacity enforcement, authoritative tracking, and a MongoDB-style in-memory filter matcher mirroring the S3 Vectors dialect (`$eq/$ne/$gt(e)/$lt(e)/$in/$nin/$and/$or`).
- **client wiring:**
  - `warm(namespace)` — scan the namespace from S3 Vectors, hydrate text from DynamoDB, hold it in RAM, mark authoritative (returns count, or 0 if it exceeds the cap).
  - **write-through** on `upsert` / `update` / `delete` keeps warmed namespaces current.
  - a **fast search path** in `_search_core` (filters, rescore, MMR all run in-process) with safe S3 fallback.
  - `hot_stats()` for residency observability.
- **tests:** 12 cases — the matcher, RAM-only serving **proven via S3/DynamoDB call counts**, write-through, filter-on-hot-path, unsupported-filter fallback, capacity fallback, delete, and text hydration.
- **docs + example:** new `In-memory hot tier` docs page and `examples/hot_tier.py`.

## Usage

```python
cfg = DynavecConfig(..., hot_tier=True, hot_tier_max_vectors=200_000)
db = Dynavec(cfg, embedder=...)
db.warm("default")                 # load S3 -> RAM (authoritative)
db.search("query", top_k=5)        # served from memory: no S3, no DynamoDB
```

## Validation

- Full suite green (all tests, incl. the 12 new hot-tier cases); `ruff check src benchmarks` clean.
- No behavior change when `hot_tier=False` (default): the S3 path is byte-for-byte the same.

## Follow-ups (not in this PR)

- Optional `hnswlib`/`faiss` backend behind the same `HotTier` interface for very large hot sets.
- Background warm-on-provision and an eviction policy for partial residency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
