### PR TITLE
feat(dashboard): dark mode + theme parity with landing page

### DIFF
--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -3,14 +3,77 @@
 @tailwind components;
 @tailwind utilities;
 
-:root { color-scheme: light; }
+/* --- Light: the landing-site palette (styles.css) --- */
+:root {
+  color-scheme: light;
+
+  --bg: #fbfaf8;          /* warm paper */
+  --surface: #ffffff;
+  --ink: #14110f;         /* warm near-black */
+  --muted: #6f6862;
+  --faint: #a99f97;
+  --line: #ece6df;
+  --accent: #e8623b;      /* coral */
+  --accent-ink: #b8472a;  /* darker coral for text/hover on light */
+  --accent-soft: #fdeee8; /* light coral wash */
+  --ok: #2f7d5b;
+  --err: #b8472a;
+
+  --track: #f0ece6;       /* meter/track fill */
+  --thead: #faf6f1;       /* table header wash */
+  --shadow: rgba(20, 17, 15, .07);
+  --scroll-thumb: #e0d9d1;
+  --tip-bg: #ffffff;      /* recharts tooltip */
+  --tip-line: #ece6df;
+
+  /* op badges */
+  --op-search-bg: #eef3ff; --op-search-fg: #3b5bdb; --op-search-line: #dbe3ff;
+  --op-graph-bg: #f3eeff;  --op-graph-fg: #7048e8;  --op-graph-line: #e5dbff;
+  --op-upsert-bg: #eafaf1; --op-upsert-fg: #2f7d5b; --op-upsert-line: #d3f0e0;
+}
+
+/* --- Dark: the site's warm inverted tones (--inv-bg #14110f / --inv-fg #fbfaf8) --- */
+.dark {
+  color-scheme: dark;
+
+  --bg: #14110f;          /* warm near-black paper */
+  --surface: #1d1916;     /* lifted warm panel */
+  --ink: #f4efe8;         /* warm off-white */
+  --muted: #a79d94;
+  --faint: #766c64;
+  --line: #2d2723;
+  --accent: #f0714a;      /* brighter coral for dark backgrounds */
+  --accent-ink: #f59a7c;  /* lighter coral for text/hover on dark */
+  --accent-soft: #2a1712; /* dark coral wash */
+  --ok: #57b98d;
+  --err: #ef8a63;
+
+  --track: #2d2723;
+  --thead: #1a1613;
+  --shadow: rgba(0, 0, 0, .4);
+  --scroll-thumb: #3a332e;
+  --tip-bg: #1d1916;
+  --tip-line: #2d2723;
+
+  --op-search-bg: #1a2233; --op-search-fg: #9db6ff; --op-search-line: #2b3a5c;
+  --op-graph-bg: #221a33;  --op-graph-fg: #b9a4f5;  --op-graph-line: #3a2e5c;
+  --op-upsert-bg: #142720; --op-upsert-fg: #57b98d; --op-upsert-line: #24463a;
+}
+
 html, body { padding: 0; margin: 0; }
 body {
-  background: theme('colors.bg');
-  color: theme('colors.ink');
+  background: var(--bg);
+  color: var(--ink);
   font-family: theme('fontFamily.sans');
-  border-top: 3px solid theme('colors.accent');
+  border-top: 3px solid var(--accent);
   -webkit-font-smoothing: antialiased;
+  transition: background-color .18s ease, color .18s ease;
 }
 ::-webkit-scrollbar { width: 10px; height: 10px; }
-::-webkit-scrollbar-thumb { background: #e0d9d1; border-radius: 6px; }
+::-webkit-scrollbar-thumb { background: var(--scroll-thumb); border-radius: 6px; }
+
+/* Trace op badges — themed via CSS variables so they flip with .dark */
+.op-badge { background: var(--op-search-bg); color: var(--op-search-fg); border-color: var(--op-search-line); }
+.op-search { background: var(--op-search-bg); color: var(--op-search-fg); border-color: var(--op-search-line); }
+.op-graph_search { background: var(--op-graph-bg); color: var(--op-graph-fg); border-color: var(--op-graph-line); }
+.op-upsert { background: var(--op-upsert-bg); color: var(--op-upsert-fg); border-color: var(--op-upsert-line); }

--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -6,9 +6,17 @@ export const metadata: Metadata = {
   description: "Real-time retrieval observability for dynavec — latency, cache, traces.",
 };
 
+// Set the theme class before first paint so there is no light→dark flash.
+// Precedence: ?theme= override (deep-linkable, used for parity screenshots) >
+// saved choice > OS preference; defaults to light (matching the site).
+const themeInit = `(function(){try{var q=new URLSearchParams(location.search).get('theme');var s=localStorage.getItem('dynavec-theme');var d=q?q==='dark':(s?s==='dark':matchMedia('(prefers-color-scheme: dark)').matches);document.documentElement.classList.toggle('dark',d);if(q){try{localStorage.setItem('dynavec-theme',d?'dark':'light');}catch(e){}}}catch(e){}})();`;
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInit }} />
+      </head>
       <body>{children}</body>
     </html>
   );

--- a/dashboard/components/LatencyChart.tsx
+++ b/dashboard/components/LatencyChart.tsx
@@ -2,9 +2,9 @@
 import type { Metrics } from "@/lib/types";
 
 const ROWS: [keyof Metrics, string, string][] = [
-  ["p50", "p50", "#2f7d5b"],
-  ["p95", "p95", "#e8623b"],
-  ["p99", "p99", "#b8472a"],
+  ["p50", "p50", "var(--ok)"],
+  ["p95", "p95", "var(--accent)"],
+  ["p99", "p99", "var(--accent-ink)"],
 ];
 
 export default function LatencyChart({ m }: { m: Metrics }) {
@@ -23,7 +23,7 @@ export default function LatencyChart({ m }: { m: Metrics }) {
                 <span className="font-mono" style={{ color }}>{label}</span>
                 <span className="font-mono">{Number(v).toFixed(1)} ms</span>
               </div>
-              <div className="h-2.5 bg-[#f0ece6] rounded-full">
+              <div className="h-2.5 bg-track rounded-full">
                 <div className="h-full rounded-full" style={{ width: `${(v / max) * 100}%`, background: color }} />
               </div>
             </div>

--- a/dashboard/components/ThemeToggle.tsx
+++ b/dashboard/components/ThemeToggle.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { useEffect, useState } from "react";
+
+// Toggles the `.dark` class on <html> and persists the choice. The initial
+// class is set pre-paint by the inline script in app/layout.tsx (no flash);
+// this component only syncs its icon to that state and flips it on click.
+export default function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    setDark(document.documentElement.classList.contains("dark"));
+  }, []);
+
+  const toggle = () => {
+    const next = !document.documentElement.classList.contains("dark");
+    document.documentElement.classList.toggle("dark", next);
+    try {
+      localStorage.setItem("dynavec-theme", next ? "dark" : "light");
+    } catch {
+      /* storage may be unavailable */
+    }
+    setDark(next);
+  };
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label={dark ? "Switch to light theme" : "Switch to dark theme"}
+      title={dark ? "Light" : "Dark"}
+      className="grid place-items-center w-8 h-8 border-[1.5px] border-ink rounded-lg bg-surface text-ink hover:text-accent"
+    >
+      {dark ? (
+        // sun
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round">
+          <circle cx="12" cy="12" r="4.2" />
+          <path d="M12 2v2.5M12 19.5V22M2 12h2.5M19.5 12H22M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M19.1 4.9l-1.8 1.8M6.7 17.3l-1.8 1.8" />
+        </svg>
+      ) : (
+        // moon
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M20 14.5A8 8 0 1 1 9.5 4a6.2 6.2 0 0 0 10.5 10.5z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/dashboard/components/TopBar.tsx
+++ b/dashboard/components/TopBar.tsx
@@ -1,4 +1,5 @@
 "use client";
+import ThemeToggle from "@/components/ThemeToggle";
 
 const RANGES = [
   { label: "30m", w: 1800 },
@@ -53,11 +54,12 @@ export default function TopBar({
         onClick={onAuto}
         className={
           "font-mono text-[12px] border-[1.5px] border-ink rounded-lg px-3 py-1.5 " +
-          (auto ? "bg-ink text-white" : "bg-surface text-ink")
+          (auto ? "bg-ink text-bg" : "bg-surface text-ink")
         }
       >
         Auto-refresh
       </button>
+      <ThemeToggle />
     </header>
   );
 }

--- a/dashboard/components/TracesTable.tsx
+++ b/dashboard/components/TracesTable.tsx
@@ -1,10 +1,11 @@
 "use client";
 import type { TraceEvent, TraceFilters } from "@/lib/types";
 
+// Themed via CSS-variable classes in globals.css so badges flip with `.dark`.
 const OP_CLASS: Record<string, string> = {
-  search: "bg-[#eef3ff] text-[#3b5bdb] border-[#dbe3ff]",
-  graph_search: "bg-[#f3eeff] text-[#7048e8] border-[#e5dbff]",
-  upsert: "bg-[#eafaf1] text-ok border-[#d3f0e0]",
+  search: "op-search",
+  graph_search: "op-graph_search",
+  upsert: "op-upsert",
 };
 
 export default function TracesTable({
@@ -54,7 +55,7 @@ export default function TracesTable({
         <div className="overflow-x-auto">
           <table className="w-full border-collapse text-[13px]">
             <thead>
-              <tr className="text-left font-mono text-[11px] uppercase tracking-wide text-muted bg-[#faf6f1]">
+              <tr className="text-left font-mono text-[11px] uppercase tracking-wide text-muted bg-thead">
                 {["Start", "Op", "Namespace", "Latency", "Results", "Cache", "Rank", "Status"].map((h) => (
                   <th key={h} className="px-[18px] py-2.5 border-b border-line font-normal">{h}</th>
                 ))}

--- a/dashboard/components/VolumeChart.tsx
+++ b/dashboard/components/VolumeChart.tsx
@@ -17,12 +17,12 @@ export default function VolumeChart({ m }: { m: Metrics }) {
           <BarChart data={data} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
             <XAxis dataKey="i" hide />
             <Tooltip
-              cursor={{ fill: "#fdeee8" }}
-              contentStyle={{ fontFamily: "JetBrains Mono", fontSize: 12, border: "1px solid #ece6df", borderRadius: 8 }}
+              cursor={{ fill: "var(--accent-soft)" }}
+              contentStyle={{ fontFamily: "JetBrains Mono", fontSize: 12, background: "var(--tip-bg)", color: "var(--ink)", border: "1px solid var(--tip-line)", borderRadius: 8 }}
               labelFormatter={() => ""}
               formatter={(v: number) => [v, "queries"]}
             />
-            <Bar dataKey="count" fill="#e8623b" radius={[2, 2, 0, 0]} />
+            <Bar dataKey="count" fill="var(--accent)" radius={[2, 2, 0, 0]} />
           </BarChart>
         </ResponsiveContainer>
       </div>

--- a/dashboard/tailwind.config.ts
+++ b/dashboard/tailwind.config.ts
@@ -1,29 +1,35 @@
 import type { Config } from "tailwindcss";
 
 // dynavec brand tokens — kept in sync with the landing page (styles.css).
+// Values are driven by CSS variables (see app/globals.css) so a single
+// `.dark` class on <html> flips the whole palette. Light is the default,
+// matching the landing site; dark uses the site's warm inverted tones.
 const config: Config = {
+  darkMode: "class",
   content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
   theme: {
     extend: {
       colors: {
-        bg: "#fbfaf8",
-        surface: "#ffffff",
-        ink: "#14110f",
-        muted: "#6f6862",
-        faint: "#a99f97",
-        line: "#ece6df",
-        accent: "#e8623b",
-        "accent-ink": "#b8472a",
-        "accent-soft": "#fdeee8",
-        ok: "#2f7d5b",
-        err: "#b8472a",
+        bg: "var(--bg)",
+        surface: "var(--surface)",
+        ink: "var(--ink)",
+        muted: "var(--muted)",
+        faint: "var(--faint)",
+        line: "var(--line)",
+        accent: "var(--accent)",
+        "accent-ink": "var(--accent-ink)",
+        "accent-soft": "var(--accent-soft)",
+        ok: "var(--ok)",
+        err: "var(--err)",
+        track: "var(--track)",
+        thead: "var(--thead)",
       },
       fontFamily: {
         sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
         mono: ['"JetBrains Mono"', 'ui-monospace', 'Menlo', 'monospace'],
       },
       boxShadow: {
-        card: "0 6px 30px rgba(20,17,15,.07)",
+        card: "0 6px 30px var(--shadow)",
       },
       borderRadius: {
         xl2: "14px",


### PR DESCRIPTION
## Description

Adds dark mode to the observability dashboard. A sun/moon toggle (top-right) flips the whole UI between light and dark; the choice is saved and applied before paint, so there's no flash. Light mode matches the landing page's colors and fonts exactly; dark mode uses the site's warm inverted tones. Implemented by driving Tailwind's color tokens through CSS variables switched by a .dark class, so every component themes automatically. 8 files, committed to development as 5cf63b8.
