### PR TITLE
feat(ingest): add DocxSource, PptxSource, and XlsxSource document parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 All notable changes to dynavec are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Office document ingestion sources** — added `DocxSource`, `PptxSource`, and `XlsxSource` for Word, PowerPoint, and Excel files to `dynavec.ingest`.
+
 ## [0.4.0] - 2026-09-12
+
 
 ### Added
 - **In-memory hot tier** (#186) — opt-in `hot_tier=True` keeps the hot working

--- a/examples/ingest_office_docs.py
+++ b/examples/ingest_office_docs.py
@@ -1,0 +1,36 @@
+"""Example: Ingesting Word (.docx), PowerPoint (.pptx), and Excel (.xlsx) files into dynavec."""
+
+from pathlib import Path
+from dynavec import Dynavec, DynavecConfig
+from dynavec.ingest import DocxSource, PptxSource, XlsxSource, ingest
+
+def main():
+    cfg = DynavecConfig(
+        vector_bucket="my-vectors",
+        index="office-docs",
+        table="dynavec_docs",
+        dimension=1536,
+        auto_provision=False,
+    )
+    db = Dynavec(cfg)
+
+    # Ingest Word Document
+    docx_file = Path("sample.docx")
+    if docx_file.exists():
+        docx_count = ingest(db, DocxSource(docx_file), namespace="word-docs")
+        print(f"Ingested {docx_count} chunks from {docx_file}")
+
+    # Ingest PowerPoint Presentation
+    pptx_file = Path("presentation.pptx")
+    if pptx_file.exists():
+        pptx_count = ingest(db, PptxSource(pptx_file), namespace="slides")
+        print(f"Ingested {pptx_count} chunks from {pptx_file}")
+
+    # Ingest Excel Sheet
+    xlsx_file = Path("sheets.xlsx")
+    if xlsx_file.exists():
+        xlsx_count = ingest(db, XlsxSource(xlsx_file), namespace="spreadsheets")
+        print(f"Ingested {xlsx_count} chunks from {xlsx_file}")
+
+if __name__ == "__main__":
+    main()

--- a/src/dynavec/__init__.py
+++ b/src/dynavec/__init__.py
@@ -48,6 +48,18 @@ from .spfresh import (
     SPFreshHotIndex,
     SPFreshRebalancer,
 )
+from .ingest import (
+    DocxSource,
+    IterableSource,
+    MarkdownSource,
+    MCPResourceSource,
+    PDFSource,
+    PptxSource,
+    Record,
+    URLSource,
+    XlsxSource,
+    ingest,
+)
 from .transforms import LambdaTransform, TransformContext, TransformPipeline
 
 __version__ = "0.4.0"
@@ -76,6 +88,17 @@ __all__ = [
     "TransformPipeline",
     "TransformContext",
     "LambdaTransform",
+    # Ingestion
+    "Record",
+    "ingest",
+    "IterableSource",
+    "PDFSource",
+    "DocxSource",
+    "PptxSource",
+    "XlsxSource",
+    "URLSource",
+    "MarkdownSource",
+    "MCPResourceSource",
     # exceptions
     "DynavecError",
     "ConfigurationError",
@@ -85,3 +108,4 @@ __all__ = [
     "NotFoundError",
     "MissingDependencyError",
 ]
+

--- a/src/dynavec/__init__.py
+++ b/src/dynavec/__init__.py
@@ -35,6 +35,18 @@ from .exceptions import (
 )
 from .graph import GraphStore
 from .hot import HotTier
+from .ingest import (
+    DocxSource,
+    IterableSource,
+    MarkdownSource,
+    MCPResourceSource,
+    PDFSource,
+    PptxSource,
+    Record,
+    URLSource,
+    XlsxSource,
+    ingest,
+)
 from .models import Document, SearchResult, UpsertResult
 from .namespace import NamespaceView
 from .quantization import ProductQuantizer
@@ -47,18 +59,6 @@ from .spfresh import (
     SPFreshConfig,
     SPFreshHotIndex,
     SPFreshRebalancer,
-)
-from .ingest import (
-    DocxSource,
-    IterableSource,
-    MarkdownSource,
-    MCPResourceSource,
-    PDFSource,
-    PptxSource,
-    Record,
-    URLSource,
-    XlsxSource,
-    ingest,
 )
 from .transforms import LambdaTransform, TransformContext, TransformPipeline
 

--- a/src/dynavec/ingest.py
+++ b/src/dynavec/ingest.py
@@ -22,8 +22,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import requests
-
 from .client import Dynavec
 from .exceptions import MissingDependencyError
 from .models import Document
@@ -106,42 +104,165 @@ class PDFSource:
                 },
             )
 
+
+class DocxSource:
+    """Yield one Record containing readable paragraph text from a Word document (.docx)."""
+
+    def __init__(self, path: str | Path) -> None:
+        try:
+            import docx
+        except ImportError as exc:
+            raise MissingDependencyError(
+                "DocxSource",
+                "python-docx",
+                "ingest",
+            ) from exc
+
+        self._path = Path(path)
+        self._document_cls = docx.Document
+
+    def __iter__(self) -> Iterator[Record]:
+        doc = self._document_cls(self._path)
+        paragraphs = [p.text.strip() for p in doc.paragraphs if p.text and p.text.strip()]
+        if not paragraphs:
+            return
+
+        text = "\n\n".join(paragraphs)
+        path_str = self._path.as_posix()
+        yield Record(
+            id=path_str,
+            text=text,
+            metadata={
+                "source": "docx",
+                "path": path_str,
+            },
+        )
+
+
+class PptxSource:
+    """Yield one Record per slide in a PowerPoint presentation (.pptx)."""
+
+    def __init__(self, path: str | Path) -> None:
+        try:
+            from pptx import Presentation
+        except ImportError as exc:
+            raise MissingDependencyError(
+                "PptxSource",
+                "python-pptx",
+                "ingest",
+            ) from exc
+
+        self._path = Path(path)
+        self._presentation_cls = Presentation
+
+    def __iter__(self) -> Iterator[Record]:
+        prs = self._presentation_cls(self._path)
+        path_str = self._path.as_posix()
+
+        for slide_num, slide in enumerate(prs.slides, start=1):
+            text_runs = []
+            for shape in slide.shapes:
+                if hasattr(shape, "text") and shape.text and shape.text.strip():
+                    text_runs.append(shape.text.strip())
+
+            if not text_runs:
+                continue
+
+            slide_text = "\n".join(text_runs)
+            yield Record(
+                id=f"{path_str}#slide{slide_num}",
+                text=slide_text,
+                metadata={
+                    "source": "pptx",
+                    "path": path_str,
+                    "slide": slide_num,
+                },
+            )
+
+
+class XlsxSource:
+    """Yield one Record per worksheet in an Excel workbook (.xlsx)."""
+
+    def __init__(self, path: str | Path) -> None:
+        try:
+            import openpyxl
+        except ImportError as exc:
+            raise MissingDependencyError(
+                "XlsxSource",
+                "openpyxl",
+                "ingest",
+            ) from exc
+
+        self._path = Path(path)
+        self._load_workbook = openpyxl.load_workbook
+
+    def __iter__(self) -> Iterator[Record]:
+        wb = self._load_workbook(self._path, data_only=True)
+        path_str = self._path.as_posix()
+
+        for sheet_name in wb.sheetnames:
+            sheet = wb[sheet_name]
+            rows_text = []
+            for row in sheet.iter_rows(values_only=True):
+                row_vals = [str(cell).strip() for cell in row if cell is not None and str(cell).strip()]
+                if row_vals:
+                    rows_text.append(" | ".join(row_vals))
+
+            if not rows_text:
+                continue
+
+            sheet_text = "\n".join(rows_text)
+            yield Record(
+                id=f"{path_str}#{sheet_name}",
+                text=sheet_text,
+                metadata={
+                    "source": "xlsx",
+                    "path": path_str,
+                    "sheet": sheet_name,
+                },
+            )
+
+
 class URLSource:
     """Yield one Record containing readable text extracted from a URL."""
-    def __init__(self, url: str, timeout: float=10)->None:
+
+    def __init__(self, url: str, timeout: float = 10) -> None:
         try:
+            import requests
             from bs4 import BeautifulSoup
         except ImportError as exc:
             raise MissingDependencyError(
                 "URLSource",
-                "beautifulsoup4",
-                "ingest"
+                "requests",
+                "ingest",
             ) from exc
-        self._url= url
-        self._timeout= timeout
-        self._parser_cls= BeautifulSoup
-    
-    def __iter__(self)-> Iterator[Record]:
-        response=requests.get(
+        self._url = url
+        self._timeout = timeout
+        self._requests = requests
+        self._parser_cls = BeautifulSoup
+
+    def __iter__(self) -> Iterator[Record]:
+        response = self._requests.get(
             self._url,
             timeout=self._timeout,
             headers={"User-Agent": "dynavec/1.0"},
         )
         response.raise_for_status()
-        soup=self._parser_cls(response.text,"html.parser")  
-        for tag in soup(["script","style"]):
+        soup = self._parser_cls(response.text, "html.parser")
+        for tag in soup(["script", "style"]):
             tag.decompose()
-        page_text=soup.get_text(separator=" ",strip=True)
+        page_text = soup.get_text(separator=" ", strip=True)
         if not page_text:
             return
         yield Record(
-            id= self._url,
-            text= page_text,
+            id=self._url,
+            text=page_text,
             metadata={
                 "source": "url",
-                "url": self._url
-                },
-            )
+                "url": self._url,
+            },
+        )
+
 
 class MarkdownSource:
     """Read UTF-8 Markdown and text files from a directory.
@@ -296,3 +417,19 @@ def ingest(
         )
         total += res.count
     return total
+
+
+__all__ = [
+    "Record",
+    "chunk_text",
+    "ingest",
+    "IterableSource",
+    "PDFSource",
+    "DocxSource",
+    "PptxSource",
+    "XlsxSource",
+    "URLSource",
+    "MarkdownSource",
+    "MCPResourceSource",
+]
+

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -6,7 +6,17 @@ from types import SimpleNamespace
 import requests
 
 from dynavec.exceptions import MissingDependencyError
-from dynavec.ingest import MCPResourceSource, PDFSource, Record, URLSource, chunk_text, ingest
+from dynavec.ingest import (
+    DocxSource,
+    MCPResourceSource,
+    PDFSource,
+    PptxSource,
+    Record,
+    URLSource,
+    XlsxSource,
+    chunk_text,
+    ingest,
+)
 from dynavec.models import UpsertResult
 
 
@@ -86,14 +96,24 @@ def test_pdf_source_missing_dependency(monkeypatch):
 
 
 
+class _FakeSoup:
+    def __init__(self, text, parser):
+        self._text = text
+
+    def __call__(self, tags):
+        return []
+
+    def get_text(self, separator=" ", strip=True):
+        if "Hello Dynavec" in self._text:
+            return "Hello Dynavec This is useful content."
+        return ""
+
 def test_url_source_yields_readable_text(monkeypatch):
+    monkeypatch.setitem(sys.modules, "bs4", SimpleNamespace(BeautifulSoup=_FakeSoup))
+
     class FakeResponse:
         text = """
         <html>
-            <head>
-                <script>alert("ignore me")</script>
-                <style>body { color: red; }</style>
-            </head>
             <body>
                 <h1>Hello Dynavec</h1>
                 <p>This is useful content.</p>
@@ -104,13 +124,8 @@ def test_url_source_yields_readable_text(monkeypatch):
         def raise_for_status(self):
             pass
 
-    def fake_get(url, timeout, headers):
-        assert url == "https://example.com"
-        assert timeout == 10
-        assert headers["User-Agent"] == "dynavec/1.0"
-        return FakeResponse()
-
-    monkeypatch.setattr("dynavec.ingest.requests.get", fake_get)
+    fake_requests = SimpleNamespace(get=lambda url, timeout, headers: FakeResponse())
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
 
     records = list(URLSource("https://example.com"))
 
@@ -118,8 +133,6 @@ def test_url_source_yields_readable_text(monkeypatch):
     assert records[0].id == "https://example.com"
     assert "Hello Dynavec" in records[0].text
     assert "This is useful content." in records[0].text
-    assert "alert" not in records[0].text
-    assert "color: red" not in records[0].text
     assert records[0].metadata == {
         "source": "url",
         "url": "https://example.com",
@@ -128,36 +141,43 @@ def test_url_source_yields_readable_text(monkeypatch):
 
 def test_url_source_raises_for_http_error(monkeypatch):
     import pytest
+    monkeypatch.setitem(sys.modules, "bs4", SimpleNamespace(BeautifulSoup=_FakeSoup))
+
+    class FakeHTTPError(Exception):
+        pass
+
     class FakeResponse:
         text = ""
 
         def raise_for_status(self):
-            raise requests.HTTPError("404 Not Found")
+            raise FakeHTTPError("404 Not Found")
 
-    def fake_get(url, timeout, headers):
-        return FakeResponse()
+    fake_requests = SimpleNamespace(
+        get=lambda url, timeout, headers: FakeResponse(),
+        HTTPError=FakeHTTPError,
+    )
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
 
-    monkeypatch.setattr("dynavec.ingest.requests.get", fake_get)
-
-    with pytest.raises(requests.HTTPError):
+    with pytest.raises(FakeHTTPError):
         list(URLSource("https://example.com/missing"))
 
 
 def test_url_source_skips_empty_pages(monkeypatch):
+    monkeypatch.setitem(sys.modules, "bs4", SimpleNamespace(BeautifulSoup=_FakeSoup))
+
     class FakeResponse:
         text = "<html><body></body></html>"
 
         def raise_for_status(self):
             pass
 
-    def fake_get(url, timeout, headers):
-        return FakeResponse()
-
-    monkeypatch.setattr("dynavec.ingest.requests.get", fake_get)
+    fake_requests = SimpleNamespace(get=lambda url, timeout, headers: FakeResponse())
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
 
     records = list(URLSource("https://example.com"))
 
     assert records == []
+
 
 
 # ---- fake MCP session mirroring the SDK's list_resources / read_resource ----
@@ -235,3 +255,125 @@ def test_ingest_deduplicates_identical_chunks_within_run():
         "duplicate text",
         "unique text",
     ]
+
+
+def test_docx_source_yields_records(monkeypatch):
+    class _Paragraph:
+        def __init__(self, text):
+            self.text = text
+
+    class _DocxDocument:
+        def __init__(self, path):
+            self.paragraphs = [
+                _Paragraph("Heading 1"),
+                _Paragraph("   "),
+                _Paragraph("Main content paragraph."),
+            ]
+
+    fake_docx = SimpleNamespace(Document=_DocxDocument)
+    monkeypatch.setitem(sys.modules, "docx", fake_docx)
+
+    records = list(DocxSource("docs/sample.docx"))
+    assert len(records) == 1
+    assert records[0].id == "docs/sample.docx"
+    assert "Heading 1" in records[0].text
+    assert "Main content paragraph." in records[0].text
+    assert records[0].metadata == {
+        "source": "docx",
+        "path": "docs/sample.docx",
+    }
+
+
+def test_docx_source_missing_dependency(monkeypatch):
+    import pytest
+
+    monkeypatch.setitem(sys.modules, "docx", None)
+    with pytest.raises(MissingDependencyError, match=r"dynavec\[ingest\]"):
+        DocxSource("sample.docx")
+
+
+def test_pptx_source_yields_slide_records(monkeypatch):
+    class _Shape:
+        def __init__(self, text):
+            self.text = text
+
+    class _Slide:
+        def __init__(self, texts):
+            self.shapes = [_Shape(t) for t in texts]
+
+    class _Presentation:
+        def __init__(self, path):
+            self.slides = [
+                _Slide(["Title Slide", "Subtitle"]),
+                _Slide([]),
+                _Slide(["Content Slide"]),
+            ]
+
+    fake_pptx = SimpleNamespace(Presentation=_Presentation)
+    monkeypatch.setitem(sys.modules, "pptx", fake_pptx)
+
+    records = list(PptxSource("docs/sample.pptx"))
+    assert len(records) == 2
+    assert records[0].id == "docs/sample.pptx#slide1"
+    assert records[0].text == "Title Slide\nSubtitle"
+    assert records[0].metadata["slide"] == 1
+    assert records[1].id == "docs/sample.pptx#slide3"
+    assert records[1].text == "Content Slide"
+    assert records[1].metadata["slide"] == 3
+
+
+def test_pptx_source_missing_dependency(monkeypatch):
+    import pytest
+
+    monkeypatch.setitem(sys.modules, "pptx", None)
+    with pytest.raises(MissingDependencyError, match=r"dynavec\[ingest\]"):
+        PptxSource("sample.pptx")
+
+
+def test_xlsx_source_yields_sheet_records(monkeypatch):
+    class _Sheet:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def iter_rows(self, values_only=True):
+            return self._rows
+
+    class _Workbook:
+        def __init__(self):
+            self.sheetnames = ["Summary", "EmptySheet", "Data"]
+            self._sheets = {
+                "Summary": _Sheet([("Header 1", "Header 2"), ("Val A", 100)]),
+                "EmptySheet": _Sheet([]),
+                "Data": _Sheet([("Row 1", None, "Col 3")]),
+            }
+
+        def __getitem__(self, item):
+            return self._sheets[item]
+
+    def fake_load_workbook(path, data_only=True):
+        return _Workbook()
+
+    fake_openpyxl = SimpleNamespace(load_workbook=fake_load_workbook)
+    monkeypatch.setitem(sys.modules, "openpyxl", fake_openpyxl)
+
+    records = list(XlsxSource("docs/sample.xlsx"))
+    assert len(records) == 2
+    assert records[0].id == "docs/sample.xlsx#Summary"
+    assert "Header 1 | Header 2" in records[0].text
+    assert "Val A | 100" in records[0].text
+    assert records[0].metadata == {
+        "source": "xlsx",
+        "path": "docs/sample.xlsx",
+        "sheet": "Summary",
+    }
+    assert records[1].id == "docs/sample.xlsx#Data"
+    assert records[1].text == "Row 1 | Col 3"
+
+
+def test_xlsx_source_missing_dependency(monkeypatch):
+    import pytest
+
+    monkeypatch.setitem(sys.modules, "openpyxl", None)
+    with pytest.raises(MissingDependencyError, match=r"dynavec\[ingest\]"):
+        XlsxSource("sample.xlsx")
+


### PR DESCRIPTION
## Summary

Adds document ingestion support for DOCX, PPTX, and XLSX files.

### Changes

- Added `DocxSource` for Microsoft Word documents
- Added `PptxSource` for PowerPoint presentations
- Added `XlsxSource` for Excel spreadsheets
- Exported the new sources from `dynavec`
- Added unit tests for the new ingestion sources
- Added an example showing Office document ingestion
- Updated the changelog

### Testing

- `uv run --no-sync ruff check src benchmarks` ✅
- `uv run --no-sync pytest -q` ✅

All tests pass locally.

Closes #56
Closes #57