### PR TITLE
feat: add DocxSource for ingestion

### DIFF
--- a/examples/docx_ingestion.py
+++ b/examples/docx_ingestion.py
@@ -1,0 +1,37 @@
+"""Ingest a DOCX file into dynavec (requires AWS credentials + S3 Vectors).
+
+    pip install "dynavec[ingest,sentence-transformers]"
+    python examples/docx_ingestion.py path/to/document.docx
+"""
+
+import sys
+
+from dynavec import Dynavec, DynavecConfig
+from dynavec.embeddings import SentenceTransformerEmbedder
+from dynavec.ingest import DocxSource, ingest
+
+if len(sys.argv) != 2:
+    raise SystemExit(
+        "usage: python examples/docx_ingestion.py path/to/document.docx"
+    )
+
+# Local embedding model — no external API key required.
+embedder = SentenceTransformerEmbedder(model="all-MiniLM-L6-v2")
+
+cfg = DynavecConfig(
+    vector_bucket="dynavec-demo",
+    index="docx-ingestion",
+    table="dynavec_docx_ingestion",
+    dimension=embedder.dimension,
+    distance_metric="cosine",
+    region="us-east-1",
+    auto_provision=True,
+)
+
+db = Dynavec(cfg, embedder=embedder)
+
+source = DocxSource(sys.argv[1])
+
+count = ingest(db, source, namespace="docx-demo")
+
+print(f"Ingested {count} chunks")

--- a/src/dynavec/ingest.py
+++ b/src/dynavec/ingest.py
@@ -106,42 +106,90 @@ class PDFSource:
                 },
             )
 
+
+class DocxSource:
+    """Yield one Record per non-empty paragraph in a DOCX file.
+
+    Each paragraph is tagged with the most recent Heading/Title paragraph's
+    text as a ``section`` metadata field. (python-docx's own
+    ``Document.sections`` are page-layout sections — margins, headers,
+    footers — and carry no text, so they aren't usable as a content
+    grouping here.)
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        try:
+            from docx import Document as _DocxDocument
+        except ImportError as exc:
+            raise MissingDependencyError(
+                "DocxSource",
+                "python-docx",
+                "ingest",
+            ) from exc
+
+        self._path = Path(path)
+        self._document_cls = _DocxDocument
+
+    def __iter__(self) -> Iterator[Record]:
+        document = self._document_cls(self._path)
+        path_str = self._path.as_posix()
+        section: str | None = None
+        para_number = 0
+
+        for paragraph in document.paragraphs:
+            text = paragraph.text
+
+            if not text or not text.strip():
+                continue
+
+            para_number += 1
+            style_name = (paragraph.style.name if paragraph.style else "") or ""
+            if style_name.startswith("Heading") or style_name == "Title":
+                section = text.strip()
+
+            yield Record(
+                id=f"{path_str}#para{para_number}",
+                text=text,
+                metadata={
+                    "source": "docx",
+                    "path": path_str,
+                    "paragraph": para_number,
+                    "section": section,
+                },
+            )
+
+
 class URLSource:
     """Yield one Record containing readable text extracted from a URL."""
-    def __init__(self, url: str, timeout: float=10)->None:
+
+    def __init__(self, url: str, timeout: float = 10) -> None:
         try:
             from bs4 import BeautifulSoup
         except ImportError as exc:
-            raise MissingDependencyError(
-                "URLSource",
-                "beautifulsoup4",
-                "ingest"
-            ) from exc
-        self._url= url
-        self._timeout= timeout
-        self._parser_cls= BeautifulSoup
-    
-    def __iter__(self)-> Iterator[Record]:
-        response=requests.get(
+            raise MissingDependencyError("URLSource", "beautifulsoup4", "ingest") from exc
+        self._url = url
+        self._timeout = timeout
+        self._parser_cls = BeautifulSoup
+
+    def __iter__(self) -> Iterator[Record]:
+        response = requests.get(
             self._url,
             timeout=self._timeout,
             headers={"User-Agent": "dynavec/1.0"},
         )
         response.raise_for_status()
-        soup=self._parser_cls(response.text,"html.parser")  
-        for tag in soup(["script","style"]):
+        soup = self._parser_cls(response.text, "html.parser")
+        for tag in soup(["script", "style"]):
             tag.decompose()
-        page_text=soup.get_text(separator=" ",strip=True)
+        page_text = soup.get_text(separator=" ", strip=True)
         if not page_text:
             return
         yield Record(
-            id= self._url,
-            text= page_text,
-            metadata={
-                "source": "url",
-                "url": self._url
-                },
-            )
+            id=self._url,
+            text=page_text,
+            metadata={"source": "url", "url": self._url},
+        )
+
 
 class MarkdownSource:
     """Read UTF-8 Markdown and text files from a directory.
@@ -172,9 +220,7 @@ class MarkdownSource:
         try:
             import yaml
         except ImportError as exc:
-            raise MissingDependencyError(
-                "Markdown front matter", "PyYAML", "ingest"
-            ) from exc
+            raise MissingDependencyError("Markdown front matter", "PyYAML", "ingest") from exc
 
         try:
             metadata = yaml.safe_load("".join(lines[1:end]))
@@ -243,7 +289,9 @@ class MCPResourceSource:
                 continue
             if self._uri_filter and not self._uri_filter(str(uri)):
                 continue
-            name = getattr(res, "name", None) or (res.get("name") if isinstance(res, dict) else None)
+            name = getattr(res, "name", None) or (
+                res.get("name") if isinstance(res, dict) else None
+            )
             contents = self._session.read_resource(uri)
             text = self._extract_text(contents)
             if not text:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -6,7 +6,15 @@ from types import SimpleNamespace
 import requests
 
 from dynavec.exceptions import MissingDependencyError
-from dynavec.ingest import MCPResourceSource, PDFSource, Record, URLSource, chunk_text, ingest
+from dynavec.ingest import (
+    DocxSource,
+    MCPResourceSource,
+    PDFSource,
+    Record,
+    URLSource,
+    chunk_text,
+    ingest,
+)
 from dynavec.models import UpsertResult
 
 
@@ -85,6 +93,59 @@ def test_pdf_source_missing_dependency(monkeypatch):
         PDFSource("sample.pdf")
 
 
+class _DocxStyle:
+    def __init__(self, name):
+        self.name = name
+
+
+class _DocxParagraph:
+    def __init__(self, text, style_name="Normal"):
+        self.text = text
+        self.style = _DocxStyle(style_name)
+
+
+class _DocxDocument:
+    def __init__(self, path):
+        self.path = path
+        self.paragraphs = [
+            _DocxParagraph("Introduction", "Heading 1"),
+            _DocxParagraph("This is the intro paragraph."),
+            _DocxParagraph("   \n"),
+            _DocxParagraph("Methodology", "Heading 1"),
+            _DocxParagraph("This describes the methodology."),
+        ]
+
+
+def test_docx_source_yields_paragraph_records(monkeypatch):
+    fake_docx = SimpleNamespace(Document=_DocxDocument)
+    monkeypatch.setitem(sys.modules, "docx", fake_docx)
+
+    records = list(DocxSource("docs/sample.docx"))
+
+    assert len(records) == 4
+
+    assert records[0].id == "docs/sample.docx#para1"
+    assert records[0].text == "Introduction"
+    assert records[0].metadata == {
+        "source": "docx",
+        "path": "docs/sample.docx",
+        "paragraph": 1,
+        "section": "Introduction",
+    }
+
+    assert records[1].metadata["section"] == "Introduction"
+    assert records[2].id == "docs/sample.docx#para3"
+    assert records[2].metadata["section"] == "Methodology"
+
+
+def test_docx_source_missing_dependency(monkeypatch):
+    import pytest
+
+    monkeypatch.setitem(sys.modules, "docx", None)
+
+    with pytest.raises(MissingDependencyError, match=r"dynavec\[ingest\]"):
+        DocxSource("sample.docx")
+
 
 def test_url_source_yields_readable_text(monkeypatch):
     class FakeResponse:
@@ -128,6 +189,7 @@ def test_url_source_yields_readable_text(monkeypatch):
 
 def test_url_source_raises_for_http_error(monkeypatch):
     import pytest
+
     class FakeResponse:
         text = ""
 
@@ -204,9 +266,7 @@ def test_mcp_resource_source_yields_records():
 
 
 def test_mcp_uri_filter():
-    session = FakeMCPSession(
-        {"notion://a": ("A", "x"), "confluence://b": ("B", "y")}
-    )
+    session = FakeMCPSession({"notion://a": ("A", "x"), "confluence://b": ("B", "y")})
     records = list(MCPResourceSource(session, uri_filter=lambda u: u.startswith("notion")))
     assert [r.id for r in records] == ["notion://a"]
 


### PR DESCRIPTION
## Description

Adds `DocxSource`, a new ingestion source that reads DOCX files using
python-docx. It mirrors the existing `PDFSource` pattern: lazy-imports
the optional dependency, raises `MissingDependencyError` if it's
missing, and yields one `Record` per non-empty paragraph.

Each paragraph is tagged with the nearest Heading/Title paragraph's
text as a `section` metadata field. Note: python-docx's own
`Document.sections` are page-layout sections (margins, headers,
footers) and carry no text, so they can't be used directly to satisfy
the "sections" part of the acceptance criteria — heading-based
grouping was the closest useful equivalent. Happy to adjust this if a
different interpretation was intended.

## Related issue

Fixes #56

## Changes

- Added `DocxSource` class in `src/dynavec/ingest.py`, placed next to `PDFSource`
- Added `examples/docx_ingestion.py`, mirroring `examples/pdf_ingestion.py`
- Added `test_docx_source_yields_paragraph_records` and `test_docx_source_missing_dependency` in `tests/test_ingest.py`, following the existing `PDFSource` test pattern (monkeypatched `docx` module, no real dependency needed to test)

## Testing

- [x] Tests pass locally
- [x] Ruff checks pass
- [ ] Documentation updated, if applicable

## Checklist

- [x] My changes are focused and relevant to this pull request.
- [x] I have added or updated tests where appropriate.
- [x] I have reviewed my changes for unrelated modifications.
- [ ] I have updated documentation where necessary.