### PR TITLE
feat(embeddings): add Hugging Face Inference API embedder backend (#6)

### DIFF
--- a/src/dynavec/embeddings/__init__.py
+++ b/src/dynavec/embeddings/__init__.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:  # for type checkers / IDEs only
     from .openai import OpenAIEmbedder
     from .sentence_transformers import SentenceTransformerEmbedder
     from .voyage import VoyageEmbedder
+    from .huggingface import HFInferenceEmbedder
 
 __all__ = [
     "Embedder",
@@ -31,6 +32,7 @@ __all__ = [
     "VoyageEmbedder",
     "MistralEmbedder",
     "OllamaEmbedder",
+    "HFInferenceEmbedder",
 ]
 
 _LAZY = {
@@ -48,6 +50,7 @@ _LAZY = {
     "VoyageEmbedder": ("dynavec.embeddings.voyage", "VoyageEmbedder"),
     "MistralEmbedder": ("dynavec.embeddings.mistral", "MistralEmbedder"),
     "OllamaEmbedder": ("dynavec.embeddings.ollama", "OllamaEmbedder"),
+    "HFInferenceEmbedder": ("dynavec.embeddings.huggingface", "HFInferenceEmbedder"),
 }
 
 

--- a/src/dynavec/embeddings/huggingface.py
+++ b/src/dynavec/embeddings/huggingface.py
@@ -1,0 +1,87 @@
+"""Hugging Face Inference API embedder."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+
+import requests
+
+from .base import Embedder, Vector
+
+_MODEL_DIMS = {
+    "BAAI/bge-small-en-v1.5": 384,
+    "BAAI/bge-large-en-v1.5": 1024,
+    "BAAI/bge-base-en-v1.5": 768,
+    "sentence-transformers/all-MiniLM-L6-v2": 384,
+    "sentence-transformers/all-mpnet-base-v2": 768,
+}
+
+
+class HFInferenceEmbedder(Embedder):
+    """Embeds text using Hugging Face Serverless Inference API."""
+
+    def __init__(
+        self,
+        model_name: str = "BAAI/bge-small-en-v1.5",
+        api_key: str | None = None,
+        batch_size: int = 32,
+        dimension: int | None = None,
+    ) -> None:
+        """Initialize HFInferenceEmbedder."""
+        self.model_name = model_name
+        self.api_key = (
+            api_key or os.getenv("HF_TOKEN") or os.getenv("HUGGINGFACE_TOKEN")
+        )
+        self.batch_size = batch_size
+        self.dimension = dimension or _MODEL_DIMS.get(model_name, 384)
+
+        if not self.api_key:
+            raise ValueError(
+                "Hugging Face API token is required. Pass api_key or set HF_TOKEN environment variable."
+            )
+
+        self.api_url = f"https://api-inference.huggingface.co/pipeline/feature-extraction/{self.model_name}"
+        self.headers = {"Authorization": f"Bearer {self.api_key}"}
+
+    def embed_documents(self, texts: Sequence[str]) -> list[Vector]:
+        """Embed a list of documents using HF Inference API with batching."""
+        if not texts:
+            return []
+
+        out: list[Vector] = []
+
+        for i in range(0, len(texts), self.batch_size):
+            chunk = list(texts[i : i + self.batch_size])
+
+            response = requests.post(
+                self.api_url,
+                headers=self.headers,
+                json={"inputs": chunk, "options": {"wait_for_model": True}},
+            )
+
+            if response.status_code != 200:
+                if response.status_code in (401, 403):
+                    raise ValueError(
+                        "Invalid Hugging Face API token or unauthorized request."
+                    )
+                elif response.status_code == 404:
+                    raise ValueError(
+                        f"Model '{self.model_name}' not found on Hugging Face Hub."
+                    )
+                else:
+                    raise RuntimeError(
+                        f"Hugging Face API request failed ({response.status_code}): {response.text}"
+                    )
+
+            data = response.json()
+            out.extend(data)
+
+        return out
+
+    def embed_query(self, text: str) -> Vector:
+        """Embed a single query string."""
+        if not text:
+            return []
+        results = self.embed_documents([text])
+        return results[0] if results else []

--- a/tests/test_huggingface_embedder.py
+++ b/tests/test_huggingface_embedder.py
@@ -1,0 +1,47 @@
+"""Unit tests for HFInferenceEmbedder."""
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+from dynavec.embeddings import HFInferenceEmbedder
+
+
+def test_import_lazy():
+    from dynavec.embeddings import HFInferenceEmbedder as Exported
+    from dynavec.embeddings.huggingface import HFInferenceEmbedder as Direct
+
+    assert Exported is Direct
+
+
+def test_missing_api_key(monkeypatch):
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HUGGINGFACE_TOKEN", raising=False)
+    with pytest.raises(ValueError, match="Hugging Face API token is required"):
+        HFInferenceEmbedder()
+
+
+def test_api_key_from_env(monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", "fake_hf_token")
+    emb = HFInferenceEmbedder()
+    assert emb.api_key == "fake_hf_token"
+    assert emb.dimension == 384
+
+
+@patch("requests.post")
+def test_embed_documents_batching(mock_post):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [[0.1, 0.2], [0.3, 0.4]]
+    mock_post.return_value = mock_response
+
+    emb = HFInferenceEmbedder(api_key="fake_token", batch_size=2)
+    res = emb.embed_documents(["a", "b", "c"])
+
+    # 3 items with batch size 2 should trigger 2 requests
+    assert mock_post.call_count == 2
+    assert len(res) == 4
+
+
+def test_empty_input():
+    emb = HFInferenceEmbedder(api_key="fake_token")
+    assert emb.embed_documents([]) == []


### PR DESCRIPTION
### Summary
Closes #6. Adds `HFInferenceEmbedder` backend to support Hugging Face Serverless Inference API.

### Key Changes
- Implemented `HFInferenceEmbedder` class in `src/dynavec/embeddings/huggingface.py`.
- Added request batching (`batch_size=32`) to prevent API payload limits.
- Added explicit HTTP error handling for 401, 403, and 404 status codes.
- Added dimension lookup fallback (`self.dimension`).
- Registered lazy import mapping in `src/dynavec/embeddings/__init__.py`.
- Added unit tests in `tests/test_huggingface_embedder.py`.

### Verification & Testing
- Code formatting/linting passed via `ruff` and `black`.
- Unit tests executed: `pytest tests/test_huggingface_embedder.py` (5/5 tests passed).